### PR TITLE
Fix reading block gress nat

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,5 +10,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45
+          version: v1.46
           args: -c .golangci.yml -v

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,5 +10,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.41
+          version: v1.45
           args: -c .golangci.yml -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,23 +3,25 @@ run:
 linters:
   enable-all: true
   disable:
-    - maligned # deprecated 1.38
+    # maligned # deprecated 1.38
     - interfacer # deprecated 1.38
     - scopelint # deprecated 1.39
     - golint # deprecated 1.41
+    - exhaustivestruct # deprecated 1.46
     - funlen
     - dupl
     - wsl
     - gomnd
     - goerr113 
     - nestif
-    - exhaustivestruct
     - paralleltest
     - gci
     - cyclop
     - forcetypeassert
     - varnamelen
     - maintidx
+    - nonamedreturns
+    - exhaustruct
 linters-settings:
   gocyclo:
     # minimal code complexity to report, 30 by default
@@ -30,6 +32,11 @@ linters-settings:
   gofumpt:
     # Choose whether to use the extra rules.
     extra-rules: true
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
 issues:
   exclude-rules:
     - text: "TLS InsecureSkipVerify set true"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,8 @@ linters:
     - forcetypeassert
     - wrapcheck
     - errorlint
+    - varnamelen
+    - maintidx
 linters-settings:
   gocyclo:
     # minimal code complexity to report, 30 by default

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,9 @@ linters-settings:
   gocognit:
     # minimal code complexity to report, 30 by default
     min-complexity: 160
+  gofumpt:
+    # Choose whether to use the extra rules.
+    extra-rules: true
 issues:
   exclude-rules:
     - text: "TLS InsecureSkipVerify set true"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
     - cyclop
     - forcetypeassert
     - wrapcheck
-    - errorlint
     - varnamelen
     - maintidx
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
     - gci
     - cyclop
     - forcetypeassert
-    - wrapcheck
     - varnamelen
     - maintidx
 linters-settings:

--- a/iptables/client.go
+++ b/iptables/client.go
@@ -54,7 +54,7 @@ type Rule struct {
 }
 
 // NewClient configure.
-func NewClient(ctx context.Context, c *Config, login string, password string) (*Client, error) {
+func NewClient(ctx context.Context, c *Config, login, password string) (*Client, error) {
 	client := &Client{
 		FirewallIP: c.firewallIP,
 		Port:       c.firewallPortAPI,
@@ -272,7 +272,7 @@ func NewClient(ctx context.Context, c *Config, login string, password string) (*
 	return client, nil
 }
 
-func (client *Client) newRequest(ctx context.Context, method string, uriString string) (*http.Request, error) {
+func (client *Client) newRequest(ctx context.Context, method, uriString string) (*http.Request, error) {
 	IP := client.FirewallIP
 	port := strconv.Itoa(client.Port)
 
@@ -508,7 +508,7 @@ func (client *Client) rawAPI(ctx context.Context, version string, rule Rule, met
 	return false, errors.New(string(body))
 }
 
-func (client *Client) chainAPI(ctx context.Context, version string, chain string, method string) (bool, error) {
+func (client *Client) chainAPI(ctx context.Context, version, chain, method string) (bool, error) {
 	var uriString []string
 	if version == "v4" {
 		uriString = append(uriString, "/chain/filter/")
@@ -594,7 +594,7 @@ func (client *Client) save(ctx context.Context, version string) error {
 	return nil
 }
 
-func (client *Client) chainAPIV4(ctx context.Context, chain string, method string) (bool, error) {
+func (client *Client) chainAPIV4(ctx context.Context, chain, method string) (bool, error) {
 	return client.chainAPI(ctx, "v4", chain, method)
 }
 
@@ -614,7 +614,7 @@ func (client *Client) saveV4(ctx context.Context) error {
 	return client.save(ctx, "v4")
 }
 
-func (client *Client) chainAPIV6(ctx context.Context, chain string, method string) (bool, error) {
+func (client *Client) chainAPIV6(ctx context.Context, chain, method string) (bool, error) {
 	return client.chainAPI(ctx, "v6", chain, method)
 }
 

--- a/iptables/client.go
+++ b/iptables/client.go
@@ -76,7 +76,7 @@ func NewClient(ctx context.Context, c *Config, login, password string) (*Client,
 		if !checkExistsRouter {
 			createChain, err := client.chainAPIV4(ctx, "router_chain", "PUT")
 			if !createChain || err != nil {
-				return nil, fmt.Errorf("create chain router failed : %s", err)
+				return nil, fmt.Errorf("create chain router failed : %w", err)
 			}
 		}
 		//	Add AllowedIPs on TCP Firewal_IP:Port
@@ -99,12 +99,12 @@ func NewClient(ctx context.Context, c *Config, login, password string) (*Client,
 			}
 			routeexists, err := client.rawAPIV4(ctx, acceptAPI, "GET")
 			if err != nil {
-				return nil, fmt.Errorf("check rules (raw) allowed IP for API for cidr %s failed : %s", cidr.(string), err)
+				return nil, fmt.Errorf("check rules (raw) allowed IP for API for cidr %s failed : %w", cidr.(string), err)
 			}
 			if !routeexists {
 				routeCIDR, err := client.rawAPIV4(ctx, acceptAPI, "PUT")
 				if !routeCIDR || err != nil {
-					return nil, fmt.Errorf("create rules (raw) allowed IP for API for cidr %s failed : %s", cidr.(string), err)
+					return nil, fmt.Errorf("create rules (raw) allowed IP for API for cidr %s failed : %w", cidr.(string), err)
 				}
 			}
 
@@ -123,12 +123,12 @@ func NewClient(ctx context.Context, c *Config, login, password string) (*Client,
 			}
 			routeexists, err = client.rulesAPIV4(ctx, acceptAPI, "GET")
 			if err != nil {
-				return nil, fmt.Errorf("check rules (ingress) allowed IP for API for cidr %s failed : %s", cidr.(string), err)
+				return nil, fmt.Errorf("check rules (ingress) allowed IP for API for cidr %s failed : %w", cidr.(string), err)
 			}
 			if !routeexists {
 				routeCIDR, err := client.rulesAPIV4(ctx, acceptAPI, "PUT")
 				if !routeCIDR || err != nil {
-					return nil, fmt.Errorf("create rules (ingress) allowed IP for API for cidr %s failed : %s", cidr.(string), err)
+					return nil, fmt.Errorf("create rules (ingress) allowed IP for API for cidr %s failed : %w", cidr.(string), err)
 				}
 			}
 
@@ -147,12 +147,12 @@ func NewClient(ctx context.Context, c *Config, login, password string) (*Client,
 			}
 			routeexists, err = client.rulesAPIV4(ctx, acceptAPI, "GET")
 			if err != nil {
-				return nil, fmt.Errorf("check rules (egress) allowed IP for API for cidr %s failed : %s", cidr.(string), err)
+				return nil, fmt.Errorf("check rules (egress) allowed IP for API for cidr %s failed : %w", cidr.(string), err)
 			}
 			if !routeexists {
 				routeCIDR, err := client.rulesAPIV4(ctx, acceptAPI, "PUT")
 				if !routeCIDR || err != nil {
-					return nil, fmt.Errorf("create rules (egress) allowed IP for API for cidr %s failed : %s", cidr.(string), err)
+					return nil, fmt.Errorf("create rules (egress) allowed IP for API for cidr %s failed : %w", cidr.(string), err)
 				}
 			}
 		}
@@ -174,12 +174,12 @@ func NewClient(ctx context.Context, c *Config, login, password string) (*Client,
 			}
 			ruleexists, err := client.rulesAPIV4(ctx, routeDefault, "GET")
 			if err != nil {
-				return nil, fmt.Errorf("check default rules %s failed : %s", table, err)
+				return nil, fmt.Errorf("check default rules %s failed : %w", table, err)
 			}
 			if !ruleexists {
 				resp, err := client.rulesAPIV4(ctx, routeDefault, "PUT")
 				if !resp || err != nil {
-					return nil, fmt.Errorf("create default rules %s failed : %s", table, err)
+					return nil, fmt.Errorf("create default rules %s failed : %w", table, err)
 				}
 			}
 			if !c.noAddDefaultDrop {
@@ -197,12 +197,12 @@ func NewClient(ctx context.Context, c *Config, login, password string) (*Client,
 				}
 				ruleexists, err = client.rulesAPIV4(ctx, ruleDrop, "GET")
 				if err != nil {
-					return nil, fmt.Errorf("check default rules drop %s failed : %s", table, err)
+					return nil, fmt.Errorf("check default rules drop %s failed : %w", table, err)
 				}
 				if !ruleexists {
 					resp, err := client.rulesAPIV4(ctx, ruleDrop, "PUT")
 					if !resp || err != nil {
-						return nil, fmt.Errorf("create default rules drop %s failed : %s", table, err)
+						return nil, fmt.Errorf("create default rules drop %s failed : %w", table, err)
 					}
 				}
 			}
@@ -215,7 +215,7 @@ func NewClient(ctx context.Context, c *Config, login, password string) (*Client,
 			if !checkExistsRouter {
 				createChain, err := client.chainAPIV6(ctx, "router_chain", "PUT")
 				if !createChain || err != nil {
-					return nil, fmt.Errorf("create chain router v6 failed : %s", err)
+					return nil, fmt.Errorf("create chain router v6 failed : %w", err)
 				}
 			}
 			for _, table := range defaultTable {
@@ -233,12 +233,12 @@ func NewClient(ctx context.Context, c *Config, login, password string) (*Client,
 				}
 				ruleexists, err := client.rulesAPIV6(ctx, routeDefault, "GET")
 				if err != nil {
-					return nil, fmt.Errorf("check default rules v6 %s failed : %s", table, err)
+					return nil, fmt.Errorf("check default rules v6 %s failed : %w", table, err)
 				}
 				if !ruleexists {
 					resp, err := client.rulesAPIV6(ctx, routeDefault, "PUT")
 					if !resp || err != nil {
-						return nil, fmt.Errorf("create default rules v6 %s failed : %s", table, err)
+						return nil, fmt.Errorf("create default rules v6 %s failed : %w", table, err)
 					}
 				}
 				if !c.noAddDefaultDrop {
@@ -256,12 +256,12 @@ func NewClient(ctx context.Context, c *Config, login, password string) (*Client,
 					}
 					ruleexists, err = client.rulesAPIV6(ctx, ruleDrop, "GET")
 					if err != nil {
-						return nil, fmt.Errorf("check default rules drop v6 %s failed : %s", table, err)
+						return nil, fmt.Errorf("check default rules drop v6 %s failed : %w", table, err)
 					}
 					if !ruleexists {
 						resp, err := client.rulesAPIV6(ctx, ruleDrop, "PUT")
 						if !resp || err != nil {
-							return nil, fmt.Errorf("create default rules drop v6 %s failed : %s", table, err)
+							return nil, fmt.Errorf("create default rules drop v6 %s failed : %w", table, err)
 						}
 					}
 				}
@@ -292,7 +292,7 @@ func (client *Client) newRequest(ctx context.Context, method, uriString string) 
 	}
 	log.Printf("[INFO] New API request: %s %s", method, urLString)
 	if err != nil {
-		return nil, fmt.Errorf("error during creation of request: %s", err)
+		return nil, fmt.Errorf("error during creation of request: %w", err)
 	}
 
 	return req, nil

--- a/iptables/client.go
+++ b/iptables/client.go
@@ -352,7 +352,7 @@ func (client *Client) rulesAPI(ctx context.Context, version string, rule Rule, m
 	if err != nil {
 		log.Printf("error when do request %s", err)
 
-		return false, err
+		return false, fmt.Errorf("error when do request %w", err)
 	}
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -414,9 +414,9 @@ func (client *Client) natAPI(ctx context.Context, version string, rule Rule, met
 	httpClient := &http.Client{Transport: tr}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		log.Printf("rrror when do request %s", err)
+		log.Printf("error when do request %s", err)
 
-		return false, err
+		return false, fmt.Errorf("error when do request %w", err)
 	}
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -489,7 +489,7 @@ func (client *Client) rawAPI(ctx context.Context, version string, rule Rule, met
 	if err != nil {
 		log.Printf("error when do request %s", err)
 
-		return false, err
+		return false, fmt.Errorf("error when do request %w", err)
 	}
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -536,7 +536,7 @@ func (client *Client) chainAPI(ctx context.Context, version, chain, method strin
 	if err != nil {
 		log.Printf("error when do request %s", err)
 
-		return false, err
+		return false, fmt.Errorf("error when do request %w", err)
 	}
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -582,7 +582,7 @@ func (client *Client) save(ctx context.Context, version string) error {
 	if err != nil {
 		log.Printf("error when do request %s", err)
 
-		return err
+		return fmt.Errorf("error when do request %w", err)
 	}
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)

--- a/iptables/client.go
+++ b/iptables/client.go
@@ -350,9 +350,9 @@ func (client *Client) rulesAPI(ctx context.Context, version string, rule Rule, m
 	httpClient := &http.Client{Transport: tr}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		log.Printf("error when do request %s", err)
+		log.Printf("error when do request: %s", err)
 
-		return false, fmt.Errorf("error when do request %w", err)
+		return false, fmt.Errorf("error when do request: %w", err)
 	}
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -414,9 +414,9 @@ func (client *Client) natAPI(ctx context.Context, version string, rule Rule, met
 	httpClient := &http.Client{Transport: tr}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		log.Printf("error when do request %s", err)
+		log.Printf("error when do request: %s", err)
 
-		return false, fmt.Errorf("error when do request %w", err)
+		return false, fmt.Errorf("error when do request: %w", err)
 	}
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -487,9 +487,9 @@ func (client *Client) rawAPI(ctx context.Context, version string, rule Rule, met
 	httpClient := &http.Client{Transport: tr}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		log.Printf("error when do request %s", err)
+		log.Printf("error when do request: %s", err)
 
-		return false, fmt.Errorf("error when do request %w", err)
+		return false, fmt.Errorf("error when do request: %w", err)
 	}
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -534,9 +534,9 @@ func (client *Client) chainAPI(ctx context.Context, version, chain, method strin
 	httpClient := &http.Client{Transport: tr}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		log.Printf("error when do request %s", err)
+		log.Printf("error when do request: %s", err)
 
-		return false, fmt.Errorf("error when do request %w", err)
+		return false, fmt.Errorf("error when do request: %w", err)
 	}
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -580,9 +580,9 @@ func (client *Client) save(ctx context.Context, version string) error {
 	httpClient := &http.Client{Transport: tr}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		log.Printf("error when do request %s", err)
+		log.Printf("error when do request: %s", err)
 
-		return fmt.Errorf("error when do request %w", err)
+		return fmt.Errorf("error when do request: %w", err)
 	}
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)

--- a/iptables/config.go
+++ b/iptables/config.go
@@ -45,7 +45,7 @@ func (c *Config) Client(ctx context.Context) (*Client, diag.Diagnostics) {
 	return client, nil
 }
 
-func getloginVault(path string, firewallIP string, key string) (string, string) {
+func getloginVault(path, firewallIP, key string) (string, string) {
 	login := ""
 	password := ""
 	client, err := vaultapi.NewClient(vaultapi.DefaultConfig())

--- a/iptables/func.go
+++ b/iptables/func.go
@@ -22,7 +22,7 @@ const (
 	protocolIntICMP         = 1
 )
 
-func computeRemove(from []interface{}, to []interface{}) []interface{} {
+func computeRemove(from, to []interface{}) []interface{} {
 	remove := make([]interface{}, 0)
 	for _, u := range from {
 		found := false
@@ -128,7 +128,7 @@ func ifaceStateFunc(v interface{}) string {
 	}
 }
 
-func computeOutSlicesOfMap(from []interface{}, to []interface{}) []interface{} {
+func computeOutSlicesOfMap(from, to []interface{}) []interface{} {
 	remove := make([]interface{}, 0)
 	for _, u := range from {
 		found := false
@@ -176,7 +176,7 @@ func checkCIDRBlocksInMap(cidrSet map[string]interface{}, vers string) error {
 	return err
 }
 
-func checkCIDRBlocksString(cidr string, vers string) error {
+func checkCIDRBlocksString(cidr, vers string) error {
 	var err error
 	switch vers {
 	case ipv4ver:
@@ -196,7 +196,7 @@ func checkCIDRBlocksString(cidr string, vers string) error {
 	return err
 }
 
-func checkCIDRNetworkOrHost(nethost string, vers string) error {
+func checkCIDRNetworkOrHost(nethost, vers string) error {
 	network := nethost
 	if !strings.Contains(network, "/") {
 		switch vers {

--- a/iptables/func_nat.go
+++ b/iptables/func_nat.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func expandCIDRInNatList(nat []interface{}, way string, version string) []interface{} {
+func expandCIDRInNatList(nat []interface{}, way, version string) []interface{} {
 	var newNat []interface{}
 
 	for _, raw := range nat {
@@ -81,7 +81,7 @@ func expandCIDRInNatList(nat []interface{}, way string, version string) []interf
 	return newNat
 }
 
-func expandCIDRInNat(nat interface{}, way string, version string) []interface{} {
+func expandCIDRInNat(nat interface{}, way, version string) []interface{} {
 	var returnNat []interface{}
 	ma := nat.(map[string]interface{})
 	if ma["except_cidr_blocks"].(string) != "" {

--- a/iptables/resource_nat.go
+++ b/iptables/resource_nat.go
@@ -401,8 +401,15 @@ func natAddOnCIDR(ctx context.Context, onCIDRList []interface{}, d *schema.Resou
 	return nil
 }
 
-func natListCommand(ctx context.Context, onCIDR string, natList []interface{}, way string, method string,
-	d *schema.ResourceData, m interface{}, cidrExpanded bool) error {
+func natListCommand(
+	ctx context.Context,
+	onCIDR string,
+	natList []interface{},
+	way, method string,
+	d *schema.ResourceData,
+	m interface{},
+	cidrExpanded bool,
+) error {
 	switch method {
 	case httpGet:
 		if cidrExpanded {

--- a/iptables/resource_nat.go
+++ b/iptables/resource_nat.go
@@ -213,7 +213,7 @@ func resourceNatUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 	client := m.(*Client)
 	err = client.saveV4(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("iptables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 	}
 
 	return nil
@@ -229,7 +229,7 @@ func resourceNatDelete(ctx context.Context, d *schema.ResourceData, m interface{
 	client := m.(*Client)
 	err = client.saveV4(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("iptables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 	}
 
 	return nil
@@ -599,56 +599,56 @@ func natCmd(ctx context.Context, onCIDR string, nat interface{}, method string, 
 	case httpDel:
 		natExistsNoPos, err := client.natAPIV4(ctx, natRuleNoPos, httpGet)
 		if err != nil {
-			return fmt.Errorf("check rules nat for %s %v failed : %s", onCIDR, natRuleNoPos, err)
+			return fmt.Errorf("check rules nat for %s %v failed : %w", onCIDR, natRuleNoPos, err)
 		}
 		if natExistsNoPos {
 			ret, err := client.natAPIV4(ctx, natRuleNoPos, httpDel)
 			if !ret || err != nil {
-				return fmt.Errorf("delete rules nat %s %v failed : %s", onCIDR, natRuleNoPos, err)
+				return fmt.Errorf("delete rules nat %s %v failed : %w", onCIDR, natRuleNoPos, err)
 			}
 		}
 	case httpPut:
 		natExists, err := client.natAPIV4(ctx, natRule, httpGet)
 		if err != nil {
-			return fmt.Errorf("check rules nat for %s %v failed : %s", onCIDR, natRule, err)
+			return fmt.Errorf("check rules nat for %s %v failed : %w", onCIDR, natRule, err)
 		}
 		if !natExists {
 			if ma["position"].(string) != "?" {
 				natExistsNoPos, err := client.natAPIV4(ctx, natRuleNoPos, httpGet)
 				if err != nil {
-					return fmt.Errorf("check rules nat for %s %v failed : %s", onCIDR, natRuleNoPos, err)
+					return fmt.Errorf("check rules nat for %s %v failed : %w", onCIDR, natRuleNoPos, err)
 				}
 				if natExistsNoPos {
 					ret, err := client.natAPIV4(ctx, natRuleNoPos, httpDel)
 					if !ret || err != nil {
-						return fmt.Errorf("delete rules with bad position on nat %s %v failed : %s", onCIDR, natRuleNoPos, err)
+						return fmt.Errorf("delete rules with bad position on nat %s %v failed : %w", onCIDR, natRuleNoPos, err)
 					}
 					ret, err = client.natAPIV4(ctx, natRule, httpPut)
 					if !ret || err != nil {
-						return fmt.Errorf("add rules nat %s %v failed : %s", onCIDR, natRule, err)
+						return fmt.Errorf("add rules nat %s %v failed : %w", onCIDR, natRule, err)
 					}
 				} else {
 					ret, err := client.natAPIV4(ctx, natRule, httpPut)
 					if !ret || err != nil {
-						return fmt.Errorf("add rules nat %s %v failed : %s", onCIDR, natRule, err)
+						return fmt.Errorf("add rules nat %s %v failed : %w", onCIDR, natRule, err)
 					}
 				}
 			} else {
 				ret, err := client.natAPIV4(ctx, natRule, httpPut)
 				if !ret || err != nil {
-					return fmt.Errorf("add rules nat %s %v failed : %s", onCIDR, natRule, err)
+					return fmt.Errorf("add rules nat %s %v failed : %w", onCIDR, natRule, err)
 				}
 			}
 		}
 	case httpGet:
 		natExists, err := client.natAPIV4(ctx, natRule, httpGet)
 		if err != nil {
-			return fmt.Errorf("check rules nat for %s %v failed : %s", onCIDR, natRule, err)
+			return fmt.Errorf("check rules nat for %s %v failed : %w", onCIDR, natRule, err)
 		}
 		if !natExists {
 			natExistsNoPos, err := client.natAPIV4(ctx, natRuleNoPos, httpGet)
 			if err != nil {
-				return fmt.Errorf("check rules nat for %s %v failed : %s", onCIDR, natRuleNoPos, err)
+				return fmt.Errorf("check rules nat for %s %v failed : %w", onCIDR, natRuleNoPos, err)
 			}
 			if natExistsNoPos {
 				return fmt.Errorf(noExistsNoPosErr)

--- a/iptables/resource_nat_ipv6.go
+++ b/iptables/resource_nat_ipv6.go
@@ -394,8 +394,15 @@ func natAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.Res
 	return nil
 }
 
-func natListCommandV6(ctx context.Context, onCIDR string, natList []interface{}, way string, method string,
-	d *schema.ResourceData, m interface{}, cidrExpanded bool) error {
+func natListCommandV6(
+	ctx context.Context,
+	onCIDR string,
+	natList []interface{},
+	way, method string,
+	d *schema.ResourceData,
+	m interface{},
+	cidrExpanded bool,
+) error {
 	switch method {
 	case httpGet:
 		if cidrExpanded {

--- a/iptables/resource_nat_ipv6.go
+++ b/iptables/resource_nat_ipv6.go
@@ -210,7 +210,7 @@ func resourceNatIPv6Update(ctx context.Context, d *schema.ResourceData, m interf
 	client := m.(*Client)
 	err = client.saveV6(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("ip6tables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 
 	return nil
@@ -226,7 +226,7 @@ func resourceNatIPv6Delete(ctx context.Context, d *schema.ResourceData, m interf
 	client := m.(*Client)
 	err = client.saveV6(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("ip6tables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 
 	return nil
@@ -603,56 +603,56 @@ func natCmdV6(ctx context.Context, onCIDR string, nat interface{}, method string
 	case httpDel:
 		natExistsNoPos, err := client.natAPIV6(ctx, natRuleNoPos, httpGet)
 		if err != nil {
-			return fmt.Errorf("check rules nat for %s %v failed : %s", onCIDR, natRuleNoPos, err)
+			return fmt.Errorf("check rules nat for %s %v failed : %w", onCIDR, natRuleNoPos, err)
 		}
 		if natExistsNoPos {
 			ret, err := client.natAPIV6(ctx, natRuleNoPos, httpDel)
 			if !ret || err != nil {
-				return fmt.Errorf("delete rules nat %s %v failed : %s", onCIDR, natRuleNoPos, err)
+				return fmt.Errorf("delete rules nat %s %v failed : %w", onCIDR, natRuleNoPos, err)
 			}
 		}
 	case httpPut:
 		natExists, err := client.natAPIV6(ctx, natRule, httpGet)
 		if err != nil {
-			return fmt.Errorf("check rules nat for %s %v failed : %s", onCIDR, natRule, err)
+			return fmt.Errorf("check rules nat for %s %v failed : %w", onCIDR, natRule, err)
 		}
 		if !natExists {
 			if ma["position"].(string) != "?" {
 				natExistsNoPos, err := client.natAPIV6(ctx, natRuleNoPos, httpGet)
 				if err != nil {
-					return fmt.Errorf("check rules nat for %s %v failed : %s", onCIDR, natRuleNoPos, err)
+					return fmt.Errorf("check rules nat for %s %v failed : %w", onCIDR, natRuleNoPos, err)
 				}
 				if natExistsNoPos {
 					ret, err := client.natAPIV6(ctx, natRuleNoPos, httpDel)
 					if !ret || err != nil {
-						return fmt.Errorf("delete rules with bad position on nat %s %v failed : %s", onCIDR, natRuleNoPos, err)
+						return fmt.Errorf("delete rules with bad position on nat %s %v failed : %w", onCIDR, natRuleNoPos, err)
 					}
 					ret, err = client.natAPIV6(ctx, natRule, httpPut)
 					if !ret || err != nil {
-						return fmt.Errorf("add rules nat %s %v failed : %s", onCIDR, natRule, err)
+						return fmt.Errorf("add rules nat %s %v failed : %w", onCIDR, natRule, err)
 					}
 				} else {
 					ret, err := client.natAPIV6(ctx, natRule, httpPut)
 					if !ret || err != nil {
-						return fmt.Errorf("add rules nat %s %v failed : %s", onCIDR, natRule, err)
+						return fmt.Errorf("add rules nat %s %v failed : %w", onCIDR, natRule, err)
 					}
 				}
 			} else {
 				ret, err := client.natAPIV6(ctx, natRule, httpPut)
 				if !ret || err != nil {
-					return fmt.Errorf("add rules nat %s %v failed : %s", onCIDR, natRule, err)
+					return fmt.Errorf("add rules nat %s %v failed : %w", onCIDR, natRule, err)
 				}
 			}
 		}
 	case httpGet:
 		natExists, err := client.natAPIV6(ctx, natRule, httpGet)
 		if err != nil {
-			return fmt.Errorf("check rules nat for %s %v failed : %s", onCIDR, natRule, err)
+			return fmt.Errorf("check rules nat for %s %v failed : %w", onCIDR, natRule, err)
 		}
 		if !natExists {
 			natExistsNoPos, err := client.natAPIV4(ctx, natRuleNoPos, httpGet)
 			if err != nil {
-				return fmt.Errorf("check rules nat for %s %v failed : %s", onCIDR, natRuleNoPos, err)
+				return fmt.Errorf("check rules nat for %s %v failed : %w", onCIDR, natRuleNoPos, err)
 			}
 			if natExistsNoPos {
 				return fmt.Errorf(noExistsNoPosErr)

--- a/iptables/resource_nat_ipv6.go
+++ b/iptables/resource_nat_ipv6.go
@@ -152,13 +152,11 @@ func resourceNatIPv6Create(ctx context.Context, d *schema.ResourceData, m interf
 func resourceNatIPv6Read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	if d.HasChange("on_cidr_blocks") {
 		oldOnCIDR, _ := d.GetChange("on_cidr_blocks")
-		err := natReadOnCIDRV6(ctx, oldOnCIDR.(*schema.Set).List(), d, m)
-		if err != nil {
+		if err := natReadOnCIDRV6(ctx, oldOnCIDR.(*schema.Set).List(), d, m); err != nil {
 			return diag.FromErr(err)
 		}
 	} else {
-		err := natReadOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m)
-		if err != nil {
+		if err := natReadOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -177,8 +175,7 @@ func resourceNatIPv6Update(ctx context.Context, d *schema.ResourceData, m interf
 		}
 	}
 
-	err := checkNatPositionAndCIDRList(d)
-	if err != nil {
+	if err := checkNatPositionAndCIDRList(d); err != nil {
 		d.SetId("")
 
 		return diag.FromErr(err)
@@ -187,29 +184,25 @@ func resourceNatIPv6Update(ctx context.Context, d *schema.ResourceData, m interf
 		oldOnCIDR, newOnCIDR := d.GetChange("on_cidr_blocks")
 		onCIDRRemove := computeRemove(oldOnCIDR.(*schema.Set).List(), newOnCIDR.(*schema.Set).List())
 
-		err = natRemoveOnCIDRV6(ctx, onCIDRRemove, d, m)
-		if err != nil {
+		if err := natRemoveOnCIDRV6(ctx, onCIDRRemove, d, m); err != nil {
 			d.SetId("")
 
 			return diag.FromErr(err)
 		}
-		err = natAddOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m)
-		if err != nil {
+		if err := natAddOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m); err != nil {
 			d.SetId("")
 
 			return diag.FromErr(err)
 		}
 	} else {
-		err = natAddOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m)
-		if err != nil {
+		if err := natAddOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m); err != nil {
 			d.SetId("")
 
 			return diag.FromErr(err)
 		}
 	}
 	client := m.(*Client)
-	err = client.saveV6(ctx)
-	if err != nil {
+	if err := client.saveV6(ctx); err != nil {
 		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 
@@ -217,15 +210,13 @@ func resourceNatIPv6Update(ctx context.Context, d *schema.ResourceData, m interf
 }
 
 func resourceNatIPv6Delete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	err := natRemoveOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m)
-	if err != nil {
+	if err := natRemoveOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m); err != nil {
 		d.SetId(d.Get("name").(string) + "!")
 
 		return diag.FromErr(err)
 	}
 	client := m.(*Client)
-	err = client.saveV6(ctx)
-	if err != nil {
+	if err := client.saveV6(ctx); err != nil {
 		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 
@@ -329,8 +320,7 @@ func natRemoveOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.
 
 func natAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.ResourceData, m interface{}) error {
 	for _, cidr := range onCIDRList {
-		err := checkCIDRBlocksString(cidr.(string), ipv6ver)
-		if err != nil {
+		if err := checkCIDRBlocksString(cidr.(string), ipv6ver); err != nil {
 			return err
 		}
 		if d.HasChange("snat") {
@@ -342,8 +332,7 @@ func natAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.Res
 			newSnatSetDiffExpanded := expandCIDRInNatList(newSnatSetDiff.List(), strSnat, ipv6ver)
 			oldSnatSetExpandedRemove := computeOutSlicesOfMap(oldSnatSetDiffExpanded, newSnatSetDiffExpanded)
 
-			err := checkNat(newSnat.(*schema.Set).List())
-			if err != nil {
+			if err := checkNat(newSnat.(*schema.Set).List()); err != nil {
 				return err
 			}
 			if _, err := natListCommandV6(
@@ -355,8 +344,7 @@ func natAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.Res
 				return err
 			}
 		} else {
-			err := checkNat(d.Get("snat").(*schema.Set).List())
-			if err != nil {
+			if err := checkNat(d.Get("snat").(*schema.Set).List()); err != nil {
 				return err
 			}
 			if _, err := natListCommandV6(
@@ -373,8 +361,7 @@ func natAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.Res
 			newDnatSetDiffExpanded := expandCIDRInNatList(newDnatSetDiff.List(), strDnat, ipv6ver)
 			oldDnatSetExpandedRemove := computeOutSlicesOfMap(oldDnatSetDiffExpanded, newDnatSetDiffExpanded)
 
-			err := checkNat(newDnat.(*schema.Set).List())
-			if err != nil {
+			if err := checkNat(newDnat.(*schema.Set).List()); err != nil {
 				return err
 			}
 			if _, err := natListCommandV6(
@@ -386,8 +373,7 @@ func natAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.Res
 				return err
 			}
 		} else {
-			err := checkNat(d.Get("dnat").(*schema.Set).List())
-			if err != nil {
+			if err := checkNat(d.Get("dnat").(*schema.Set).List()); err != nil {
 				return err
 			}
 			if _, err := natListCommandV6(
@@ -419,8 +405,7 @@ func natListCommandV6(
 			natOKnoPos := false
 			natExpanded := expandCIDRInNat(natElement, way, ipv6ver)
 			for _, natExpandedElement := range natExpanded {
-				err := natCmdV6(ctx, onCIDR, natExpandedElement, httpGet, m)
-				if err != nil {
+				if err := natCmdV6(ctx, onCIDR, natExpandedElement, httpGet, m); err != nil {
 					if !strings.Contains(err.Error(), noExists) {
 						return nil, err
 					}
@@ -443,8 +428,7 @@ func natListCommandV6(
 	case httpDel:
 		if cidrExpanded {
 			for _, natElement := range natList {
-				err := natCmdV6(ctx, onCIDR, natElement, httpDel, m)
-				if err != nil {
+				if err := natCmdV6(ctx, onCIDR, natElement, httpDel, m); err != nil {
 					return nil, err
 				}
 			}
@@ -452,8 +436,7 @@ func natListCommandV6(
 			for _, natElement := range natList {
 				natExpanded := expandCIDRInNat(natElement, way, ipv6ver)
 				for _, natExpandedElement := range natExpanded {
-					err := natCmdV6(ctx, onCIDR, natExpandedElement, httpDel, m)
-					if err != nil {
+					if err := natCmdV6(ctx, onCIDR, natExpandedElement, httpDel, m); err != nil {
 						return nil, err
 					}
 				}
@@ -464,12 +447,10 @@ func natListCommandV6(
 	case httpPut:
 		if cidrExpanded {
 			for _, natElement := range natList {
-				err := checkCIDRBlocksInMap(natElement.(map[string]interface{}), ipv6ver)
-				if err != nil {
+				if err := checkCIDRBlocksInMap(natElement.(map[string]interface{}), ipv6ver); err != nil {
 					return nil, err
 				}
-				err = natCmdV6(ctx, onCIDR, natElement, httpPut, m)
-				if err != nil {
+				if err := natCmdV6(ctx, onCIDR, natElement, httpPut, m); err != nil {
 					return nil, err
 				}
 			}
@@ -477,12 +458,10 @@ func natListCommandV6(
 			for _, natElement := range natList {
 				natExpand := expandCIDRInNat(natElement, way, ipv6ver)
 				for _, natExpandElement := range natExpand {
-					err := checkCIDRBlocksInMap(natExpandElement.(map[string]interface{}), ipv6ver)
-					if err != nil {
+					if err := checkCIDRBlocksInMap(natExpandElement.(map[string]interface{}), ipv6ver); err != nil {
 						return nil, err
 					}
-					err = natCmdV6(ctx, onCIDR, natExpandElement, httpPut, m)
-					if err != nil {
+					if err := natCmdV6(ctx, onCIDR, natExpandElement, httpPut, m); err != nil {
 						return nil, err
 					}
 				}
@@ -502,8 +481,7 @@ func natCmdV6(ctx context.Context, onCIDR string, nat interface{}, method string
 	}
 
 	ma := nat.(map[string]interface{})
-	err := checkCIDRBlocksInMap(ma, ipv6ver)
-	if err != nil {
+	if err := checkCIDRBlocksInMap(ma, ipv6ver); err != nil {
 		return err
 	}
 	var dstOk string

--- a/iptables/resource_project.go
+++ b/iptables/resource_project.go
@@ -325,8 +325,9 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, m interf
 	return nil
 }
 
-func cidrForProject(ctx context.Context,
-	cidr string, position int, method string, d *schema.ResourceData, m interface{}) (bool, error) {
+func cidrForProject(
+	ctx context.Context, cidr string, position int, method string, d *schema.ResourceData, m interface{},
+) (bool, error) {
 	routerChain := "router_chain"
 	if position != 0 {
 		routerChain = strings.Join([]string{"router_chain_pos", strconv.Itoa(position)}, "")

--- a/iptables/resource_project.go
+++ b/iptables/resource_project.go
@@ -48,12 +48,12 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	checkExists, err := client.chainAPIV4(ctx, d.Get("name").(string), httpGet)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("check if project %s exist failed : %s", d.Get("name"), err))
+		return diag.FromErr(fmt.Errorf("check if project %s exist failed : %w", d.Get("name"), err))
 	}
 	if !checkExists {
 		create, err := client.chainAPIV4(ctx, d.Get("name").(string), httpPut)
 		if !create || err != nil {
-			return diag.FromErr(fmt.Errorf("create project %s failed : %s", d.Get("name"), err))
+			return diag.FromErr(fmt.Errorf("create project %s failed : %w", d.Get("name"), err))
 		}
 	} else {
 		return diag.FromErr(fmt.Errorf("project %s already exist", d.Get("name")))
@@ -68,7 +68,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	checkExists, err := client.chainAPIV4(ctx, d.Get("name").(string), httpGet)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("read project %s failed : %s", d.Get("name"), err))
+		return diag.FromErr(fmt.Errorf("read project %s failed : %w", d.Get("name"), err))
 	}
 	if !checkExists {
 		d.SetId("")
@@ -79,7 +79,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 		routerChainName := strings.Join([]string{"router_chain_pos", strconv.Itoa(absolute(d.Get("position").(int)))}, "")
 		checkExists, err := client.chainAPIV4(ctx, routerChainName, httpGet)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("read chain router_chain_pos %s failed : %s", routerChainName, err))
+			return diag.FromErr(fmt.Errorf("read chain router_chain_pos %s failed : %w", routerChainName, err))
 		}
 		if !checkExists {
 			tfErr := d.Set("position", 0)
@@ -89,7 +89,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 		}
 		routerChainPos, err := insertPosrouter(ctx, absolute(d.Get("position").(int)), httpGet, m)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("read position %d in router_chain failed : %s", d.Get("position").(int), err))
+			return diag.FromErr(fmt.Errorf("read position %d in router_chain failed : %w", d.Get("position").(int), err))
 		}
 		if !routerChainPos {
 			tfErr := d.Set("position", absolute(d.Get("position").(int))*-1)
@@ -155,7 +155,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 					panic(tfErr)
 				}
 
-				return diag.FromErr(fmt.Errorf("delete rule for position %d failed : %s", oPos.(int), err))
+				return diag.FromErr(fmt.Errorf("delete rule for position %d failed : %w", oPos.(int), err))
 			}
 			routerChainName := strings.Join([]string{"router_chain_pos", strconv.Itoa(absolute(oPos.(int)))}, "")
 			routeChainDel, err := client.chainAPIV4(ctx, routerChainName, httpDel)
@@ -165,7 +165,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 					panic(tfErr)
 				}
 
-				return diag.FromErr(fmt.Errorf("delete chain %s failed : %s", routerChainName, err))
+				return diag.FromErr(fmt.Errorf("delete chain %s failed : %w", routerChainName, err))
 			}
 			tfErr := d.Set("position", 0)
 			if tfErr != nil {
@@ -181,7 +181,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 					panic(tfErr)
 				}
 
-				return diag.FromErr(fmt.Errorf("check if chain %s exist failed : %s", routerChainName, err))
+				return diag.FromErr(fmt.Errorf("check if chain %s exist failed : %w", routerChainName, err))
 			}
 			if checkExists {
 				tfErr := d.Set("position", 0)
@@ -198,7 +198,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 					panic(tfErr)
 				}
 
-				return diag.FromErr(fmt.Errorf("create chain %s for position : %s", routerChainName, err))
+				return diag.FromErr(fmt.Errorf("create chain %s for position : %w", routerChainName, err))
 			}
 			createPos, err := insertPosrouter(ctx, nPos.(int), httpPut, m)
 			if !createPos || err != nil {
@@ -218,7 +218,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 					panic(tfErr)
 				}
 
-				return diag.FromErr(fmt.Errorf("insert position in router_chain failed : %s", err))
+				return diag.FromErr(fmt.Errorf("insert position in router_chain failed : %w", err))
 			}
 			if !d.HasChange("cidr_blocks") {
 				for _, cidr := range d.Get("cidr_blocks").(*schema.Set).List() {
@@ -233,7 +233,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 				}
 				err := client.saveV4(ctx)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("iptables save failed : %s", err))
+					return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 				}
 			}
 		}
@@ -261,7 +261,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		}
 		err := client.saveV4(ctx)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("iptables save failed : %s", err))
+			return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 		}
 	}
 	if positionChange {
@@ -303,23 +303,23 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, m interf
 
 	chainDeleted, err := client.chainAPIV4(ctx, d.Get("name").(string), httpDel)
 	if !chainDeleted || err != nil {
-		return diag.FromErr(fmt.Errorf("delete project %s failed : %s", d.Get("name"), err))
+		return diag.FromErr(fmt.Errorf("delete project %s failed : %w", d.Get("name"), err))
 	}
 	if d.Get("position").(int) != 0 {
 		rulePosDel, err := insertPosrouter(ctx, absolute(d.Get("position").(int)), httpDel, m)
 		if !rulePosDel || err != nil {
-			return diag.FromErr(fmt.Errorf("delete rule for position %d failed : %s", d.Get("position").(int), err))
+			return diag.FromErr(fmt.Errorf("delete rule for position %d failed : %w", d.Get("position").(int), err))
 		}
 		routerChainName := strings.Join([]string{"router_chain_pos", strconv.Itoa(absolute(d.Get("position").(int)))}, "")
 		routeChainDel, err := client.chainAPIV4(ctx, routerChainName, httpDel)
 		if !routeChainDel || err != nil {
-			return diag.FromErr(fmt.Errorf("delete chain %s failed : %s", routerChainName, err))
+			return diag.FromErr(fmt.Errorf("delete chain %s failed : %w", routerChainName, err))
 		}
 	}
 	d.SetId("")
 	err = client.saveV4(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("iptables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 	}
 
 	return nil
@@ -350,18 +350,18 @@ func cidrForProject(
 
 	routeexists, err := client.rulesAPIV4(ctx, route, httpGet)
 	if err != nil {
-		return routeexists, fmt.Errorf("check rules for cidr %s failed : %s", cidr, err)
+		return routeexists, fmt.Errorf("check rules for cidr %s failed : %w", cidr, err)
 	}
 	if !routeexists && method == httpPut {
 		routeCIDR, err := client.rulesAPIV4(ctx, route, httpPut)
 		if !routeCIDR || err != nil {
-			return routeexists, fmt.Errorf("create rules source for cidr %s failed : %s", cidr, err)
+			return routeexists, fmt.Errorf("create rules source for cidr %s failed : %w", cidr, err)
 		}
 	}
 	if routeexists && method == httpDel {
 		routeCIDR, err := client.rulesAPIV4(ctx, route, httpDel)
 		if !routeCIDR || err != nil {
-			return routeexists, fmt.Errorf("delete rules source for cidr %s failed : %s", cidr, err)
+			return routeexists, fmt.Errorf("delete rules source for cidr %s failed : %w", cidr, err)
 		}
 	}
 	if !routeexists && method == httpGet {
@@ -383,18 +383,18 @@ func cidrForProject(
 	// Apply on table filter route for destination cidr
 	routeexists, err = client.rulesAPIV4(ctx, route, httpGet)
 	if err != nil {
-		return routeexists, fmt.Errorf("check rules for cidr %s failed : %s", cidr, err)
+		return routeexists, fmt.Errorf("check rules for cidr %s failed : %w", cidr, err)
 	}
 	if !routeexists && method == httpPut {
 		routeCIDR, err := client.rulesAPIV4(ctx, route, httpPut)
 		if !routeCIDR || err != nil {
-			return routeexists, fmt.Errorf("create rules destination for cidr %s failed : %s", cidr, err)
+			return routeexists, fmt.Errorf("create rules destination for cidr %s failed : %w", cidr, err)
 		}
 	}
 	if routeexists && method == httpDel {
 		routeCIDR, err := client.rulesAPIV4(ctx, route, httpDel)
 		if !routeCIDR || err != nil {
-			return routeexists, fmt.Errorf("delete rules destination for cidr %s failed : %s", cidr, err)
+			return routeexists, fmt.Errorf("delete rules destination for cidr %s failed : %w", cidr, err)
 		}
 	}
 	if !routeexists && method == httpGet {
@@ -432,31 +432,31 @@ func insertPosrouter(ctx context.Context, position int, method string, m interfa
 	}
 	routeexists, err := client.rulesAPIV4(ctx, route, httpGet)
 	if err != nil {
-		return routeexists, fmt.Errorf("check rules for project position %d failed : %s", position, err)
+		return routeexists, fmt.Errorf("check rules for project position %d failed : %w", position, err)
 	}
 	if !routeexists && method == httpPut {
 		routePut, err := client.rulesAPIV4(ctx, route, httpPut)
 		if !routePut || err != nil {
-			return routeexists, fmt.Errorf("create rules for project position %d failed : %s", position, err)
+			return routeexists, fmt.Errorf("create rules for project position %d failed : %w", position, err)
 		}
 	}
 	if method == httpDel {
 		if routeexists {
 			routeDel, err := client.rulesAPIV4(ctx, route, httpDel)
 			if !routeDel || err != nil {
-				return routeexists, fmt.Errorf("delete rules for project position %d failed : %s", position, err)
+				return routeexists, fmt.Errorf("delete rules for project position %d failed : %w", position, err)
 			}
 		} else {
 			routeexistsNoPos, err := client.rulesAPIV4(ctx, routeNoPos, httpGet)
 			if err != nil {
 				return routeexistsNoPos, fmt.Errorf("check rules for project position "+
-					"with bad position %d failed : %s", position, err)
+					"with bad position %d failed : %w", position, err)
 			}
 			if routeexistsNoPos {
 				routeDel, err := client.rulesAPIV4(ctx, routeNoPos, httpDel)
 				if !routeDel || err != nil {
 					return routeexistsNoPos, fmt.Errorf("delete rules for project position "+
-						"with bad position %d failed : %s", position, err)
+						"with bad position %d failed : %w", position, err)
 				}
 			}
 		}

--- a/iptables/resource_project.go
+++ b/iptables/resource_project.go
@@ -82,8 +82,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 			return diag.FromErr(fmt.Errorf("read chain router_chain_pos %s failed : %w", routerChainName, err))
 		}
 		if !checkExists {
-			tfErr := d.Set("position", 0)
-			if tfErr != nil {
+			if tfErr := d.Set("position", 0); tfErr != nil {
 				panic(tfErr)
 			}
 		}
@@ -92,13 +91,11 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 			return diag.FromErr(fmt.Errorf("read position %d in router_chain failed : %w", d.Get("position").(int), err))
 		}
 		if !routerChainPos {
-			tfErr := d.Set("position", absolute(d.Get("position").(int))*-1)
-			if tfErr != nil {
+			if tfErr := d.Set("position", absolute(d.Get("position").(int))*-1); tfErr != nil {
 				panic(tfErr)
 			}
 		} else {
-			tfErr := d.Set("position", absolute(d.Get("position").(int)))
-			if tfErr != nil {
+			if tfErr := d.Set("position", absolute(d.Get("position").(int))); tfErr != nil {
 				panic(tfErr)
 			}
 		}
@@ -110,8 +107,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 			listCIDRSet = append(listCIDRSet, cidr.(string))
 		}
 	}
-	tfErr := d.Set("cidr_blocks", listCIDRSet)
-	if tfErr != nil {
+	if tfErr := d.Set("cidr_blocks", listCIDRSet); tfErr != nil {
 		panic(tfErr)
 	}
 	d.SetId(d.Get("name").(string) + "!")
@@ -129,19 +125,15 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		oPos, nPos = d.GetChange("position")
 		if oPos.(int) != 0 {
 			for _, cidr := range d.Get("cidr_blocks").(*schema.Set).List() {
-				err := checkCIDRBlocksString(cidr.(string), ipv4ver)
-				if err != nil {
-					tfErr := d.Set("position", oPos.(int))
-					if tfErr != nil {
+				if err := checkCIDRBlocksString(cidr.(string), ipv4ver); err != nil {
+					if tfErr := d.Set("position", oPos.(int)); tfErr != nil {
 						panic(tfErr)
 					}
 
 					return diag.FromErr(err)
 				}
-				_, err = cidrForProject(ctx, cidr.(string), 0, httpPut, d, m)
-				if err != nil {
-					tfErr := d.Set("position", oPos.(int))
-					if tfErr != nil {
+				if _, err := cidrForProject(ctx, cidr.(string), 0, httpPut, d, m); err != nil {
+					if tfErr := d.Set("position", oPos.(int)); tfErr != nil {
 						panic(tfErr)
 					}
 
@@ -150,8 +142,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			}
 			rulePosDel, err := insertPosrouter(ctx, absolute(oPos.(int)), httpDel, m)
 			if !rulePosDel || err != nil {
-				tfErr := d.Set("position", oPos.(int))
-				if tfErr != nil {
+				if tfErr := d.Set("position", oPos.(int)); tfErr != nil {
 					panic(tfErr)
 				}
 
@@ -160,15 +151,13 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			routerChainName := strings.Join([]string{"router_chain_pos", strconv.Itoa(absolute(oPos.(int)))}, "")
 			routeChainDel, err := client.chainAPIV4(ctx, routerChainName, httpDel)
 			if !routeChainDel || err != nil {
-				tfErr := d.Set("position", oPos.(int))
-				if tfErr != nil {
+				if tfErr := d.Set("position", oPos.(int)); tfErr != nil {
 					panic(tfErr)
 				}
 
 				return diag.FromErr(fmt.Errorf("delete chain %s failed : %w", routerChainName, err))
 			}
-			tfErr := d.Set("position", 0)
-			if tfErr != nil {
+			if tfErr := d.Set("position", 0); tfErr != nil {
 				panic(tfErr)
 			}
 		}
@@ -176,16 +165,14 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			routerChainName := strings.Join([]string{"router_chain_pos", strconv.Itoa(nPos.(int))}, "")
 			checkExists, err := client.chainAPIV4(ctx, routerChainName, httpGet)
 			if err != nil {
-				tfErr := d.Set("position", 0)
-				if tfErr != nil {
+				if tfErr := d.Set("position", 0); tfErr != nil {
 					panic(tfErr)
 				}
 
 				return diag.FromErr(fmt.Errorf("check if chain %s exist failed : %w", routerChainName, err))
 			}
 			if checkExists {
-				tfErr := d.Set("position", 0)
-				if tfErr != nil {
+				if tfErr := d.Set("position", 0); tfErr != nil {
 					panic(tfErr)
 				}
 
@@ -193,8 +180,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			}
 			create, err := client.chainAPIV4(ctx, routerChainName, httpPut)
 			if !create || err != nil {
-				tfErr := d.Set("position", 0)
-				if tfErr != nil {
+				if tfErr := d.Set("position", 0); tfErr != nil {
 					panic(tfErr)
 				}
 
@@ -204,8 +190,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			if !createPos || err != nil {
 				removeChainPos, err2 := client.chainAPIV4(ctx, routerChainName, httpDel)
 				if !removeChainPos || err2 != nil {
-					tfErr := d.Set("position", 0)
-					if tfErr != nil {
+					if tfErr := d.Set("position", 0); tfErr != nil {
 						panic(tfErr)
 					}
 
@@ -213,8 +198,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 						"error for delete router_chain_pos %s (please delete manually) : %s",
 						err, routerChainName, err2))
 				}
-				tfErr := d.Set("position", 0)
-				if tfErr != nil {
+				if tfErr := d.Set("position", 0); tfErr != nil {
 					panic(tfErr)
 				}
 
@@ -222,17 +206,14 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			}
 			if !d.HasChange("cidr_blocks") {
 				for _, cidr := range d.Get("cidr_blocks").(*schema.Set).List() {
-					err := checkCIDRBlocksString(cidr.(string), ipv4ver)
-					if err != nil {
+					if err := checkCIDRBlocksString(cidr.(string), ipv4ver); err != nil {
 						return diag.FromErr(err)
 					}
-					_, err = cidrForProject(ctx, cidr.(string), nPos.(int), httpPut, d, m)
-					if err != nil {
+					if _, err := cidrForProject(ctx, cidr.(string), nPos.(int), httpPut, d, m); err != nil {
 						return diag.FromErr(err)
 					}
 				}
-				err := client.saveV4(ctx)
-				if err != nil {
+				if err := client.saveV4(ctx); err != nil {
 					return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 				}
 			}
@@ -244,23 +225,19 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		oldCIDR, newCIDR := d.GetChange("cidr_blocks")
 		cidrListRemove := computeRemove(oldCIDR.(*schema.Set).List(), newCIDR.(*schema.Set).List())
 		for _, cidr := range cidrListRemove {
-			_, err := cidrForProject(ctx, cidr.(string), nPos.(int), httpDel, d, m)
-			if err != nil {
+			if _, err := cidrForProject(ctx, cidr.(string), nPos.(int), httpDel, d, m); err != nil {
 				return diag.FromErr(err)
 			}
 		}
 		for _, cidr := range d.Get("cidr_blocks").(*schema.Set).List() {
-			err := checkCIDRBlocksString(cidr.(string), ipv4ver)
-			if err != nil {
+			if err := checkCIDRBlocksString(cidr.(string), ipv4ver); err != nil {
 				return diag.FromErr(err)
 			}
-			_, err = cidrForProject(ctx, cidr.(string), nPos.(int), httpPut, d, m)
-			if err != nil {
+			if _, err := cidrForProject(ctx, cidr.(string), nPos.(int), httpPut, d, m); err != nil {
 				return diag.FromErr(err)
 			}
 		}
-		err := client.saveV4(ctx)
-		if err != nil {
+		if err := client.saveV4(ctx); err != nil {
 			return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 		}
 	}
@@ -268,23 +245,20 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		if d.HasChange("cidr_blocks") && oPos.(int) == 0 && nPos.(int) > 0 {
 			oldCIDR, _ := d.GetChange("cidr_blocks")
 			for _, cidr := range oldCIDR.(*schema.Set).List() {
-				_, err := cidrForProject(ctx, cidr.(string), 0, httpDel, d, m)
-				if err != nil {
+				if _, err := cidrForProject(ctx, cidr.(string), 0, httpDel, d, m); err != nil {
 					return diag.FromErr(err)
 				}
 			}
 		}
 		if nPos.(int) > 0 {
 			for _, cidr := range d.Get("cidr_blocks").(*schema.Set).List() {
-				_, err := cidrForProject(ctx, cidr.(string), 0, httpDel, d, m)
-				if err != nil {
+				if _, err := cidrForProject(ctx, cidr.(string), 0, httpDel, d, m); err != nil {
 					return diag.FromErr(err)
 				}
 			}
 		}
 	}
-	tfErr := d.Set("position", nPos.(int))
-	if tfErr != nil {
+	if tfErr := d.Set("position", nPos.(int)); tfErr != nil {
 		panic(tfErr)
 	}
 
@@ -295,14 +269,12 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, m interf
 	client := m.(*Client)
 	cidrListRemove := d.Get("cidr_blocks").(*schema.Set).List()
 	for _, cidr := range cidrListRemove {
-		_, err := cidrForProject(ctx, cidr.(string), absolute(d.Get("position").(int)), httpDel, d, m)
-		if err != nil {
+		if _, err := cidrForProject(ctx, cidr.(string), absolute(d.Get("position").(int)), httpDel, d, m); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	chainDeleted, err := client.chainAPIV4(ctx, d.Get("name").(string), httpDel)
-	if !chainDeleted || err != nil {
+	if chainDeleted, err := client.chainAPIV4(ctx, d.Get("name").(string), httpDel); !chainDeleted || err != nil {
 		return diag.FromErr(fmt.Errorf("delete project %s failed : %w", d.Get("name"), err))
 	}
 	if d.Get("position").(int) != 0 {
@@ -317,8 +289,7 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, m interf
 		}
 	}
 	d.SetId("")
-	err = client.saveV4(ctx)
-	if err != nil {
+	if err := client.saveV4(ctx); err != nil {
 		return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 	}
 

--- a/iptables/resource_project_ipv6.go
+++ b/iptables/resource_project_ipv6.go
@@ -48,12 +48,12 @@ func resourceProjectIPv6Create(ctx context.Context, d *schema.ResourceData, m in
 	}
 	checkExists, err := client.chainAPIV6(ctx, d.Get("name").(string), httpGet)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("check if project %s exist failed : %s", d.Get("name"), err))
+		return diag.FromErr(fmt.Errorf("check if project %s exist failed : %w", d.Get("name"), err))
 	}
 	if !checkExists {
 		create, err := client.chainAPIV6(ctx, d.Get("name").(string), httpPut)
 		if !create || err != nil {
-			return diag.FromErr(fmt.Errorf("create project %s failed : %s", d.Get("name"), err))
+			return diag.FromErr(fmt.Errorf("create project %s failed : %w", d.Get("name"), err))
 		}
 	} else {
 		return diag.FromErr(fmt.Errorf("project %s already exist", d.Get("name")))
@@ -72,7 +72,7 @@ func resourceProjectIPv6Read(ctx context.Context, d *schema.ResourceData, m inte
 
 	checkExists, err := client.chainAPIV6(ctx, d.Get("name").(string), httpGet)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("read project %s failed : %s", d.Get("name"), err))
+		return diag.FromErr(fmt.Errorf("read project %s failed : %w", d.Get("name"), err))
 	}
 	if !checkExists {
 		d.SetId("")
@@ -83,7 +83,7 @@ func resourceProjectIPv6Read(ctx context.Context, d *schema.ResourceData, m inte
 		routerChainName := strings.Join([]string{"router_chain_pos", strconv.Itoa(absolute(d.Get("position").(int)))}, "")
 		checkExists, err := client.chainAPIV6(ctx, routerChainName, httpGet)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("read chain router_chain_pos %s failed : %s", routerChainName, err))
+			return diag.FromErr(fmt.Errorf("read chain router_chain_pos %s failed : %w", routerChainName, err))
 		}
 		if !checkExists {
 			tfErr := d.Set("position", 0)
@@ -93,7 +93,7 @@ func resourceProjectIPv6Read(ctx context.Context, d *schema.ResourceData, m inte
 		}
 		routerChainPos, err := insertPosrouterV6(ctx, absolute(d.Get("position").(int)), httpGet, m)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("read position %d in router_chain failed : %s", d.Get("position").(int), err))
+			return diag.FromErr(fmt.Errorf("read position %d in router_chain failed : %w", d.Get("position").(int), err))
 		}
 		if !routerChainPos {
 			tfErr := d.Set("position", absolute(d.Get("position").(int))*-1)
@@ -164,7 +164,7 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 					panic(tfErr)
 				}
 
-				return diag.FromErr(fmt.Errorf("delete rule for position %d failed : %s", oPos.(int), err))
+				return diag.FromErr(fmt.Errorf("delete rule for position %d failed : %w", oPos.(int), err))
 			}
 			routerChainName := strings.Join([]string{"router_chain_pos", strconv.Itoa(absolute(oPos.(int)))}, "")
 			routeChainDel, err := client.chainAPIV6(ctx, routerChainName, httpDel)
@@ -174,7 +174,7 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 					panic(tfErr)
 				}
 
-				return diag.FromErr(fmt.Errorf("delete chain %s failed : %s", routerChainName, err))
+				return diag.FromErr(fmt.Errorf("delete chain %s failed : %w", routerChainName, err))
 			}
 			tfErr := d.Set("position", 0)
 			if tfErr != nil {
@@ -190,7 +190,7 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 					panic(tfErr)
 				}
 
-				return diag.FromErr(fmt.Errorf("check if chain %s exist failed : %s", routerChainName, err))
+				return diag.FromErr(fmt.Errorf("check if chain %s exist failed : %w", routerChainName, err))
 			}
 			if checkExists {
 				tfErr := d.Set("position", 0)
@@ -207,7 +207,7 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 					panic(tfErr)
 				}
 
-				return diag.FromErr(fmt.Errorf("create chain %s for position : %s", routerChainName, err))
+				return diag.FromErr(fmt.Errorf("create chain %s for position : %w", routerChainName, err))
 			}
 			createPos, err := insertPosrouterV6(ctx, nPos.(int), httpPut, m)
 			if !createPos || err != nil {
@@ -227,7 +227,7 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 					panic(tfErr)
 				}
 
-				return diag.FromErr(fmt.Errorf("insert position in router_chain failed : %s", err))
+				return diag.FromErr(fmt.Errorf("insert position in router_chain failed : %w", err))
 			}
 			if !d.HasChange("cidr_blocks") {
 				for _, cidr := range d.Get("cidr_blocks").(*schema.Set).List() {
@@ -243,7 +243,7 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 
 				err := client.saveV6(ctx)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf("ip6tables save failed : %s", err))
+					return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 				}
 			}
 		}
@@ -272,7 +272,7 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 
 		err := client.saveV6(ctx)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("ip6tables save failed : %s", err))
+			return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 		}
 	}
 	if positionChange {
@@ -318,23 +318,23 @@ func resourceProjectIPv6Delete(ctx context.Context, d *schema.ResourceData, m in
 	}
 	chainDeleted, err := client.chainAPIV6(ctx, d.Get("name").(string), httpDel)
 	if !chainDeleted || err != nil {
-		return diag.FromErr(fmt.Errorf("delete project %s failed : %s", d.Get("name"), err))
+		return diag.FromErr(fmt.Errorf("delete project %s failed : %w", d.Get("name"), err))
 	}
 	if d.Get("position").(int) != 0 {
 		rulePosDel, err := insertPosrouterV6(ctx, absolute(d.Get("position").(int)), httpDel, m)
 		if !rulePosDel || err != nil {
-			return diag.FromErr(fmt.Errorf("delete rule for position %d failed : %s", d.Get("position").(int), err))
+			return diag.FromErr(fmt.Errorf("delete rule for position %d failed : %w", d.Get("position").(int), err))
 		}
 		routerChainName := strings.Join([]string{"router_chain_pos", strconv.Itoa(absolute(d.Get("position").(int)))}, "")
 		routeChainDel, err := client.chainAPIV6(ctx, routerChainName, httpDel)
 		if !routeChainDel || err != nil {
-			return diag.FromErr(fmt.Errorf("delete chain %s failed : %s", routerChainName, err))
+			return diag.FromErr(fmt.Errorf("delete chain %s failed : %w", routerChainName, err))
 		}
 	}
 	d.SetId("")
 	err = client.saveV6(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("ip6tables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 
 	return nil
@@ -366,18 +366,18 @@ func cidrForProjectV6(
 
 	routeexists, err := client.rulesAPIV6(ctx, route, httpGet)
 	if err != nil {
-		return routeexists, fmt.Errorf("check rules for cidr %s failed : %s", cidr, err)
+		return routeexists, fmt.Errorf("check rules for cidr %s failed : %w", cidr, err)
 	}
 	if !routeexists && method == httpPut {
 		routeCIDR, err := client.rulesAPIV6(ctx, route, httpPut)
 		if !routeCIDR || err != nil {
-			return routeexists, fmt.Errorf("create rules source for cidr %s failed : %s", cidr, err)
+			return routeexists, fmt.Errorf("create rules source for cidr %s failed : %w", cidr, err)
 		}
 	}
 	if routeexists && method == httpDel {
 		routeCIDR, err := client.rulesAPIV6(ctx, route, httpDel)
 		if !routeCIDR || err != nil {
-			return routeexists, fmt.Errorf("delete rules source for cidr %s failed : %s", cidr, err)
+			return routeexists, fmt.Errorf("delete rules source for cidr %s failed : %w", cidr, err)
 		}
 	}
 	if routeexists && method == httpGet {
@@ -399,18 +399,18 @@ func cidrForProjectV6(
 	// Apply on table filter route for destination cidr
 	routeexists, err = client.rulesAPIV6(ctx, route, httpGet)
 	if err != nil {
-		return routeexists, fmt.Errorf("check rules for cidr %s failed : %s", cidr, err)
+		return routeexists, fmt.Errorf("check rules for cidr %s failed : %w", cidr, err)
 	}
 	if !routeexists && method == httpPut {
 		routeCIDR, err := client.rulesAPIV6(ctx, route, httpPut)
 		if !routeCIDR || err != nil {
-			return routeexists, fmt.Errorf("create rules destination for cidr %s failed : %s", cidr, err)
+			return routeexists, fmt.Errorf("create rules destination for cidr %s failed : %w", cidr, err)
 		}
 	}
 	if routeexists && method == httpDel {
 		routeCIDR, err := client.rulesAPIV6(ctx, route, httpDel)
 		if !routeCIDR || err != nil {
-			return routeexists, fmt.Errorf("delete rules destination for cidr %s failed : %s", cidr, err)
+			return routeexists, fmt.Errorf("delete rules destination for cidr %s failed : %w", cidr, err)
 		}
 	}
 	if !routeexists && method == httpGet {
@@ -448,19 +448,19 @@ func insertPosrouterV6(ctx context.Context, position int, method string, m inter
 	}
 	routeexists, err := client.rulesAPIV6(ctx, route, httpGet)
 	if err != nil {
-		return routeexists, fmt.Errorf("check rules for project position %d failed : %s", position, err)
+		return routeexists, fmt.Errorf("check rules for project position %d failed : %w", position, err)
 	}
 	if !routeexists && method == httpPut {
 		routePut, err := client.rulesAPIV6(ctx, route, httpPut)
 		if !routePut || err != nil {
-			return routeexists, fmt.Errorf("create rules for project position %d failed : %s", position, err)
+			return routeexists, fmt.Errorf("create rules for project position %d failed : %w", position, err)
 		}
 	}
 	if method == httpDel {
 		if routeexists {
 			routeDel, err := client.rulesAPIV6(ctx, route, httpDel)
 			if !routeDel || err != nil {
-				return routeexists, fmt.Errorf("delete rules for project position %d failed : %s", position, err)
+				return routeexists, fmt.Errorf("delete rules for project position %d failed : %w", position, err)
 			}
 		} else {
 			routeexistsNoPos, err := client.rulesAPIV4(ctx, routeNoPos, httpGet)
@@ -472,7 +472,7 @@ func insertPosrouterV6(ctx context.Context, position int, method string, m inter
 				routeDel, err := client.rulesAPIV4(ctx, routeNoPos, httpDel)
 				if !routeDel || err != nil {
 					return routeexistsNoPos, fmt.Errorf("delete rules for project position "+
-						"with bad position %d failed : %s", position, err)
+						"with bad position %d failed : %w", position, err)
 				}
 			}
 		}

--- a/iptables/resource_project_ipv6.go
+++ b/iptables/resource_project_ipv6.go
@@ -340,8 +340,9 @@ func resourceProjectIPv6Delete(ctx context.Context, d *schema.ResourceData, m in
 	return nil
 }
 
-func cidrForProjectV6(ctx context.Context,
-	cidr string, position int, method string, d *schema.ResourceData, m interface{}) (bool, error) {
+func cidrForProjectV6(
+	ctx context.Context, cidr string, position int, method string, d *schema.ResourceData, m interface{},
+) (bool, error) {
 	routerChain := "router_chain"
 	if position != 0 {
 		routerChain = strings.Join([]string{"router_chain_pos", strconv.Itoa(absolute(d.Get("position").(int)))}, "")

--- a/iptables/resource_project_ipv6.go
+++ b/iptables/resource_project_ipv6.go
@@ -86,8 +86,7 @@ func resourceProjectIPv6Read(ctx context.Context, d *schema.ResourceData, m inte
 			return diag.FromErr(fmt.Errorf("read chain router_chain_pos %s failed : %w", routerChainName, err))
 		}
 		if !checkExists {
-			tfErr := d.Set("position", 0)
-			if tfErr != nil {
+			if tfErr := d.Set("position", 0); tfErr != nil {
 				panic(tfErr)
 			}
 		}
@@ -96,13 +95,11 @@ func resourceProjectIPv6Read(ctx context.Context, d *schema.ResourceData, m inte
 			return diag.FromErr(fmt.Errorf("read position %d in router_chain failed : %w", d.Get("position").(int), err))
 		}
 		if !routerChainPos {
-			tfErr := d.Set("position", absolute(d.Get("position").(int))*-1)
-			if tfErr != nil {
+			if tfErr := d.Set("position", absolute(d.Get("position").(int))*-1); tfErr != nil {
 				panic(tfErr)
 			}
 		} else {
-			tfErr := d.Set("position", absolute(d.Get("position").(int)))
-			if tfErr != nil {
+			if tfErr := d.Set("position", absolute(d.Get("position").(int))); tfErr != nil {
 				panic(tfErr)
 			}
 		}
@@ -115,8 +112,7 @@ func resourceProjectIPv6Read(ctx context.Context, d *schema.ResourceData, m inte
 			listCIDRSet = append(listCIDRSet, cidr.(string))
 		}
 	}
-	tfErr := d.Set("cidr_blocks", listCIDRSet)
-	if tfErr != nil {
+	if tfErr := d.Set("cidr_blocks", listCIDRSet); tfErr != nil {
 		panic(tfErr)
 	}
 	d.SetId(d.Get("name").(string) + "!")
@@ -138,19 +134,15 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 		oPos, nPos = d.GetChange("position")
 		if oPos.(int) != 0 {
 			for _, cidr := range d.Get("cidr_blocks").(*schema.Set).List() {
-				err := checkCIDRBlocksString(cidr.(string), ipv6ver)
-				if err != nil {
-					tfErr := d.Set("position", oPos.(int))
-					if tfErr != nil {
+				if err := checkCIDRBlocksString(cidr.(string), ipv6ver); err != nil {
+					if tfErr := d.Set("position", oPos.(int)); tfErr != nil {
 						panic(tfErr)
 					}
 
 					return diag.FromErr(err)
 				}
-				_, err = cidrForProjectV6(ctx, cidr.(string), 0, httpPut, d, m)
-				if err != nil {
-					tfErr := d.Set("position", oPos.(int))
-					if tfErr != nil {
+				if _, err := cidrForProjectV6(ctx, cidr.(string), 0, httpPut, d, m); err != nil {
+					if tfErr := d.Set("position", oPos.(int)); tfErr != nil {
 						panic(tfErr)
 					}
 
@@ -159,8 +151,7 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 			}
 			rulePosDel, err := insertPosrouterV6(ctx, absolute(oPos.(int)), httpDel, m)
 			if !rulePosDel || err != nil {
-				tfErr := d.Set("position", oPos.(int))
-				if tfErr != nil {
+				if tfErr := d.Set("position", oPos.(int)); tfErr != nil {
 					panic(tfErr)
 				}
 
@@ -169,15 +160,13 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 			routerChainName := strings.Join([]string{"router_chain_pos", strconv.Itoa(absolute(oPos.(int)))}, "")
 			routeChainDel, err := client.chainAPIV6(ctx, routerChainName, httpDel)
 			if !routeChainDel || err != nil {
-				tfErr := d.Set("position", oPos.(int))
-				if tfErr != nil {
+				if tfErr := d.Set("position", oPos.(int)); tfErr != nil {
 					panic(tfErr)
 				}
 
 				return diag.FromErr(fmt.Errorf("delete chain %s failed : %w", routerChainName, err))
 			}
-			tfErr := d.Set("position", 0)
-			if tfErr != nil {
+			if tfErr := d.Set("position", 0); tfErr != nil {
 				panic(tfErr)
 			}
 		}
@@ -185,16 +174,14 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 			routerChainName := strings.Join([]string{"router_chain_pos", strconv.Itoa(nPos.(int))}, "")
 			checkExists, err := client.chainAPIV6(ctx, routerChainName, httpGet)
 			if err != nil {
-				tfErr := d.Set("position", 0)
-				if tfErr != nil {
+				if tfErr := d.Set("position", 0); tfErr != nil {
 					panic(tfErr)
 				}
 
 				return diag.FromErr(fmt.Errorf("check if chain %s exist failed : %w", routerChainName, err))
 			}
 			if checkExists {
-				tfErr := d.Set("position", 0)
-				if tfErr != nil {
+				if tfErr := d.Set("position", 0); tfErr != nil {
 					panic(tfErr)
 				}
 
@@ -202,8 +189,7 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 			}
 			create, err := client.chainAPIV6(ctx, routerChainName, httpPut)
 			if !create || err != nil {
-				tfErr := d.Set("position", 0)
-				if tfErr != nil {
+				if tfErr := d.Set("position", 0); tfErr != nil {
 					panic(tfErr)
 				}
 
@@ -213,8 +199,7 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 			if !createPos || err != nil {
 				removeChainPos, err2 := client.chainAPIV6(ctx, routerChainName, httpDel)
 				if !removeChainPos || err2 != nil {
-					tfErr := d.Set("position", 0)
-					if tfErr != nil {
+					if tfErr := d.Set("position", 0); tfErr != nil {
 						panic(tfErr)
 					}
 
@@ -222,8 +207,7 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 						"error for delete router_chain_pos %s (please delete manually) : %s",
 						err, routerChainName, err2))
 				}
-				tfErr := d.Set("position", 0)
-				if tfErr != nil {
+				if tfErr := d.Set("position", 0); tfErr != nil {
 					panic(tfErr)
 				}
 
@@ -231,18 +215,15 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 			}
 			if !d.HasChange("cidr_blocks") {
 				for _, cidr := range d.Get("cidr_blocks").(*schema.Set).List() {
-					err := checkCIDRBlocksString(cidr.(string), ipv6ver)
-					if err != nil {
+					if err := checkCIDRBlocksString(cidr.(string), ipv6ver); err != nil {
 						return diag.FromErr(err)
 					}
-					_, err = cidrForProjectV6(ctx, cidr.(string), nPos.(int), httpPut, d, m)
-					if err != nil {
+					if _, err = cidrForProjectV6(ctx, cidr.(string), nPos.(int), httpPut, d, m); err != nil {
 						return diag.FromErr(err)
 					}
 				}
 
-				err := client.saveV6(ctx)
-				if err != nil {
+				if err := client.saveV6(ctx); err != nil {
 					return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 				}
 			}
@@ -254,24 +235,20 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 		oldCIDR, newCIDR := d.GetChange("cidr_blocks")
 		cidrListRemove := computeRemove(oldCIDR.(*schema.Set).List(), newCIDR.(*schema.Set).List())
 		for _, cidr := range cidrListRemove {
-			_, err := cidrForProjectV6(ctx, cidr.(string), nPos.(int), httpDel, d, m)
-			if err != nil {
+			if _, err := cidrForProjectV6(ctx, cidr.(string), nPos.(int), httpDel, d, m); err != nil {
 				return diag.FromErr(err)
 			}
 		}
 		for _, cidr := range d.Get("cidr_blocks").(*schema.Set).List() {
-			err := checkCIDRBlocksString(cidr.(string), ipv6ver)
-			if err != nil {
+			if err := checkCIDRBlocksString(cidr.(string), ipv6ver); err != nil {
 				return diag.FromErr(err)
 			}
-			_, err = cidrForProjectV6(ctx, cidr.(string), nPos.(int), httpPut, d, m)
-			if err != nil {
+			if _, err := cidrForProjectV6(ctx, cidr.(string), nPos.(int), httpPut, d, m); err != nil {
 				return diag.FromErr(err)
 			}
 		}
 
-		err := client.saveV6(ctx)
-		if err != nil {
+		if err := client.saveV6(ctx); err != nil {
 			return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 		}
 	}
@@ -279,23 +256,20 @@ func resourceProjectIPv6Update(ctx context.Context, d *schema.ResourceData, m in
 		if d.HasChange("cidr_blocks") && oPos.(int) == 0 && nPos.(int) > 0 {
 			oldCIDR, _ := d.GetChange("cidr_blocks")
 			for _, cidr := range oldCIDR.(*schema.Set).List() {
-				_, err := cidrForProjectV6(ctx, cidr.(string), 0, httpDel, d, m)
-				if err != nil {
+				if _, err := cidrForProjectV6(ctx, cidr.(string), 0, httpDel, d, m); err != nil {
 					return diag.FromErr(err)
 				}
 			}
 		}
 		if nPos.(int) > 0 {
 			for _, cidr := range d.Get("cidr_blocks").(*schema.Set).List() {
-				_, err := cidrForProjectV6(ctx, cidr.(string), 0, httpDel, d, m)
-				if err != nil {
+				if _, err := cidrForProjectV6(ctx, cidr.(string), 0, httpDel, d, m); err != nil {
 					return diag.FromErr(err)
 				}
 			}
 		}
 	}
-	tfErr := d.Set("position", nPos.(int))
-	if tfErr != nil {
+	if tfErr := d.Set("position", nPos.(int)); tfErr != nil {
 		panic(tfErr)
 	}
 
@@ -311,13 +285,11 @@ func resourceProjectIPv6Delete(ctx context.Context, d *schema.ResourceData, m in
 
 	cidrListRemove := d.Get("cidr_blocks").(*schema.Set).List()
 	for _, cidr := range cidrListRemove {
-		_, err := cidrForProjectV6(ctx, cidr.(string), absolute(d.Get("position").(int)), httpDel, d, m)
-		if err != nil {
+		if _, err := cidrForProjectV6(ctx, cidr.(string), absolute(d.Get("position").(int)), httpDel, d, m); err != nil {
 			return diag.FromErr(err)
 		}
 	}
-	chainDeleted, err := client.chainAPIV6(ctx, d.Get("name").(string), httpDel)
-	if !chainDeleted || err != nil {
+	if chainDeleted, err := client.chainAPIV6(ctx, d.Get("name").(string), httpDel); !chainDeleted || err != nil {
 		return diag.FromErr(fmt.Errorf("delete project %s failed : %w", d.Get("name"), err))
 	}
 	if d.Get("position").(int) != 0 {
@@ -332,8 +304,7 @@ func resourceProjectIPv6Delete(ctx context.Context, d *schema.ResourceData, m in
 		}
 	}
 	d.SetId("")
-	err = client.saveV6(ctx)
-	if err != nil {
+	if err := client.saveV6(ctx); err != nil {
 		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 

--- a/iptables/resource_raw.go
+++ b/iptables/resource_raw.go
@@ -126,8 +126,7 @@ func resourceRawRead(ctx context.Context, d *schema.ResourceData, m interface{})
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		tfErr := d.Set("rule", rawList)
-		if tfErr != nil {
+		if tfErr := d.Set("rule", rawList); tfErr != nil {
 			panic(tfErr)
 		}
 	} else {
@@ -137,8 +136,7 @@ func resourceRawRead(ctx context.Context, d *schema.ResourceData, m interface{})
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		tfErr := d.Set("rule", rawList)
-		if tfErr != nil {
+		if tfErr := d.Set("rule", rawList); tfErr != nil {
 			panic(tfErr)
 		}
 	}
@@ -162,14 +160,12 @@ func resourceRawUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 		newRuleSetDiff := newRuleSet.Difference(oldRuleSet)
 
 		oldRuleSetRemove := computeOutSlicesOfMap(oldRuleSetDiff.List(), newRuleSetDiff.List())
-		_, err := rawRule(ctx, oldRuleSetRemove, httpDel, m)
-		if err != nil {
+		if _, err := rawRule(ctx, oldRuleSetRemove, httpDel, m); err != nil {
 			d.SetId("")
 
 			return diag.FromErr(err)
 		}
-		_, err = rawRule(ctx, newRuleSet.List(), httpPut, m)
-		if err != nil {
+		if _, err := rawRule(ctx, newRuleSet.List(), httpPut, m); err != nil {
 			d.SetId("")
 
 			return diag.FromErr(err)
@@ -186,13 +182,11 @@ func resourceRawUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 func resourceRawDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	rule := d.Get("rule")
 	ruleSet := rule.(*schema.Set)
-	_, err := rawRule(ctx, ruleSet.List(), httpDel, m)
-	if err != nil {
+	if _, err := rawRule(ctx, ruleSet.List(), httpDel, m); err != nil {
 		return diag.FromErr(err)
 	}
 	client := m.(*Client)
-	err = client.saveV4(ctx)
-	if err != nil {
+	if err := client.saveV4(ctx); err != nil {
 		return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 	}
 

--- a/iptables/resource_raw.go
+++ b/iptables/resource_raw.go
@@ -177,7 +177,7 @@ func resourceRawUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 	}
 	client := m.(*Client)
 	if err := client.saveV4(ctx); err != nil {
-		return diag.FromErr(fmt.Errorf("iptables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 	}
 
 	return nil
@@ -193,7 +193,7 @@ func resourceRawDelete(ctx context.Context, d *schema.ResourceData, m interface{
 	client := m.(*Client)
 	err = client.saveV4(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("iptables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 	}
 
 	return nil
@@ -273,51 +273,51 @@ func rawRule(ctx context.Context, ruleList []interface{}, method string, m inter
 		case httpDel:
 			ruleexistsNoPos, err := client.rawAPIV4(ctx, ruleNoPos, httpGet)
 			if err != nil {
-				return nil, fmt.Errorf("check rules on raw for %s failed : %s", ma, err)
+				return nil, fmt.Errorf("check rules on raw for %s failed : %w", ma, err)
 			}
 			if ruleexistsNoPos {
 				ret, err := client.rawAPIV4(ctx, ruleNoPos, httpDel)
 				if !ret || err != nil {
-					return nil, fmt.Errorf("delete rules on raw %s failed : %s", ma, err)
+					return nil, fmt.Errorf("delete rules on raw %s failed : %w", ma, err)
 				}
 			}
 		case httpPut:
 			ruleexists, err := client.rawAPIV4(ctx, rule, httpGet)
 			if err != nil {
-				return nil, fmt.Errorf("check rules on raw for %s failed : %s", ma, err)
+				return nil, fmt.Errorf("check rules on raw for %s failed : %w", ma, err)
 			}
 			if !ruleexists {
 				if ma["position"].(string) != "?" {
 					ruleexistsNoPos, err := client.rawAPIV4(ctx, ruleNoPos, httpGet)
 					if err != nil {
-						return nil, fmt.Errorf("check rules on raw for %s failed : %s", ma, err)
+						return nil, fmt.Errorf("check rules on raw for %s failed : %w", ma, err)
 					}
 					if ruleexistsNoPos {
 						ret, err := client.rawAPIV4(ctx, ruleNoPos, httpDel)
 						if !ret || err != nil {
-							return nil, fmt.Errorf("delete rules with bad position on raw %s failed : %s", ma, err)
+							return nil, fmt.Errorf("delete rules with bad position on raw %s failed : %w", ma, err)
 						}
 						ret, err = client.rawAPIV4(ctx, rule, httpPut)
 						if !ret || err != nil {
-							return nil, fmt.Errorf("add rules on raw %s failed : %s", ma, err)
+							return nil, fmt.Errorf("add rules on raw %s failed : %w", ma, err)
 						}
 					} else {
 						ret, err := client.rawAPIV4(ctx, rule, httpPut)
 						if !ret || err != nil {
-							return nil, fmt.Errorf("add rules on raw %s failed %s", ma, err)
+							return nil, fmt.Errorf("add rules on raw %s failed %w", ma, err)
 						}
 					}
 				} else {
 					ret, err := client.rawAPIV4(ctx, rule, httpPut)
 					if !ret || err != nil {
-						return nil, fmt.Errorf("add rules on raw %s failed : %s", ma, err)
+						return nil, fmt.Errorf("add rules on raw %s failed : %w", ma, err)
 					}
 				}
 			}
 		case httpGet:
 			ruleexists, err := client.rawAPIV4(ctx, rule, httpGet)
 			if err != nil {
-				return ruleListReturn, fmt.Errorf("check rules on raw for %s failed : %s", ma, err)
+				return ruleListReturn, fmt.Errorf("check rules on raw for %s failed : %w", ma, err)
 			}
 			if ruleexists {
 				ruleListReturn = append(ruleListReturn, ma)

--- a/iptables/resource_raw_ipv6.go
+++ b/iptables/resource_raw_ipv6.go
@@ -126,8 +126,7 @@ func resourceRawIPv6Read(ctx context.Context, d *schema.ResourceData, m interfac
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		tfErr := d.Set("rule", rawList)
-		if tfErr != nil {
+		if tfErr := d.Set("rule", rawList); tfErr != nil {
 			panic(tfErr)
 		}
 	} else {
@@ -137,8 +136,7 @@ func resourceRawIPv6Read(ctx context.Context, d *schema.ResourceData, m interfac
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		tfErr := d.Set("rule", rawList)
-		if tfErr != nil {
+		if tfErr := d.Set("rule", rawList); tfErr != nil {
 			panic(tfErr)
 		}
 	}
@@ -162,14 +160,12 @@ func resourceRawIPv6Update(ctx context.Context, d *schema.ResourceData, m interf
 		newRuleSetDiff := newRuleSet.Difference(oldRuleSet)
 
 		oldRuleSetRemove := computeOutSlicesOfMap(oldRuleSetDiff.List(), newRuleSetDiff.List())
-		_, err := rawRuleV6(ctx, oldRuleSetRemove, httpDel, m)
-		if err != nil {
+		if _, err := rawRuleV6(ctx, oldRuleSetRemove, httpDel, m); err != nil {
 			d.SetId("")
 
 			return diag.FromErr(err)
 		}
-		_, err = rawRuleV6(ctx, newRuleSet.List(), httpPut, m)
-		if err != nil {
+		if _, err := rawRuleV6(ctx, newRuleSet.List(), httpPut, m); err != nil {
 			d.SetId("")
 
 			return diag.FromErr(err)
@@ -186,13 +182,11 @@ func resourceRawIPv6Update(ctx context.Context, d *schema.ResourceData, m interf
 func resourceRawIPv6Delete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	rule := d.Get("rule")
 	ruleSet := rule.(*schema.Set)
-	_, err := rawRuleV6(ctx, ruleSet.List(), httpDel, m)
-	if err != nil {
+	if _, err := rawRuleV6(ctx, ruleSet.List(), httpDel, m); err != nil {
 		return diag.FromErr(err)
 	}
 	client := m.(*Client)
-	err = client.saveV6(ctx)
-	if err != nil {
+	if err := client.saveV6(ctx); err != nil {
 		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 

--- a/iptables/resource_raw_ipv6.go
+++ b/iptables/resource_raw_ipv6.go
@@ -177,7 +177,7 @@ func resourceRawIPv6Update(ctx context.Context, d *schema.ResourceData, m interf
 	}
 	client := m.(*Client)
 	if err := client.saveV6(ctx); err != nil {
-		return diag.FromErr(fmt.Errorf("ip6tables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 
 	return nil
@@ -193,7 +193,7 @@ func resourceRawIPv6Delete(ctx context.Context, d *schema.ResourceData, m interf
 	client := m.(*Client)
 	err = client.saveV6(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("ip6tables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 
 	return nil
@@ -277,44 +277,44 @@ func rawRuleV6(ctx context.Context, ruleList []interface{}, method string, m int
 		case httpDel:
 			ruleexistsNoPos, err := client.rawAPIV6(ctx, ruleNoPos, httpGet)
 			if err != nil {
-				return nil, fmt.Errorf("check rules on raw for %s failed : %s", ma, err)
+				return nil, fmt.Errorf("check rules on raw for %s failed : %w", ma, err)
 			}
 			if ruleexistsNoPos {
 				ret, err := client.rawAPIV6(ctx, ruleNoPos, httpDel)
 				if !ret || err != nil {
-					return nil, fmt.Errorf("delete rules on raw %s failed : %s", ma, err)
+					return nil, fmt.Errorf("delete rules on raw %s failed : %w", ma, err)
 				}
 			}
 		case httpPut:
 			ruleexists, err := client.rawAPIV6(ctx, rule, httpGet)
 			if err != nil {
-				return nil, fmt.Errorf("check rules on raw for %s failed : %s", ma, err)
+				return nil, fmt.Errorf("check rules on raw for %s failed : %w", ma, err)
 			}
 			if !ruleexists {
 				if ma["position"].(string) != "?" {
 					ruleexistsNoPos, err := client.rawAPIV6(ctx, ruleNoPos, httpGet)
 					if err != nil {
-						return nil, fmt.Errorf("check rules on raw for %s failed : %s", ma, err)
+						return nil, fmt.Errorf("check rules on raw for %s failed : %w", ma, err)
 					}
 					if ruleexistsNoPos {
 						ret, err := client.rawAPIV6(ctx, ruleNoPos, httpDel)
 						if !ret || err != nil {
-							return nil, fmt.Errorf("delete rules with bad position on raw %s failed : %s", ma, err)
+							return nil, fmt.Errorf("delete rules with bad position on raw %s failed : %w", ma, err)
 						}
 						ret, err = client.rawAPIV6(ctx, rule, httpPut)
 						if !ret || err != nil {
-							return nil, fmt.Errorf("add rules on raw %s failed : %s", ma, err)
+							return nil, fmt.Errorf("add rules on raw %s failed : %w", ma, err)
 						}
 					} else {
 						ret, err := client.rawAPIV6(ctx, rule, httpPut)
 						if !ret || err != nil {
-							return nil, fmt.Errorf("add rules on raw %s failed : %s", ma, err)
+							return nil, fmt.Errorf("add rules on raw %s failed : %w", ma, err)
 						}
 					}
 				} else {
 					ret, err := client.rawAPIV6(ctx, rule, httpPut)
 					if !ret || err != nil {
-						return nil, fmt.Errorf("add rules on raw %s failed : %s", ma, err)
+						return nil, fmt.Errorf("add rules on raw %s failed : %w", ma, err)
 					}
 				}
 			}

--- a/iptables/resource_rules.go
+++ b/iptables/resource_rules.go
@@ -330,30 +330,36 @@ func resourceRulesDelete(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func rulesReadOnCIDR(ctx context.Context, onCIDRList []interface{}, d *schema.ResourceData, m interface{}) error {
+	ingress := d.Get("ingress").(*schema.Set).List()
+	if d.HasChange("ingress") {
+		oldIngress, _ := d.GetChange("ingress")
+		ingress = oldIngress.(*schema.Set).List()
+	}
+	egress := d.Get("egress").(*schema.Set).List()
+	if d.HasChange("egress") {
+		oldEgress, _ := d.GetChange("egress")
+		egress = oldEgress.(*schema.Set).List()
+	}
 	for _, cidr := range onCIDRList {
-		if d.HasChange("ingress") {
-			oldIngress, _ := d.GetChange("ingress")
-			err := gressListCommand(ctx, cidr.(string), oldIngress.(*schema.Set).List(), wayIngress, httpGet, d, m, false)
-			if err != nil {
-				return err
-			}
-		} else {
-			err := gressListCommand(ctx, cidr.(string), d.Get("ingress").(*schema.Set).List(), wayIngress, httpGet, d, m, false)
-			if err != nil {
-				return err
-			}
+		// ingress
+		ingressRead, err := gressListCommand(ctx, cidr.(string), ingress, wayIngress, httpGet, d, m, false)
+		if err != nil {
+			return err
 		}
-		if d.HasChange("egress") {
-			oldEgress, _ := d.GetChange("egress")
-			err := gressListCommand(ctx, cidr.(string), oldEgress.(*schema.Set).List(), wayEgress, httpGet, d, m, false)
-			if err != nil {
-				return err
-			}
-		} else {
-			err := gressListCommand(ctx, cidr.(string), d.Get("egress").(*schema.Set).List(), wayEgress, httpGet, d, m, false)
-			if err != nil {
-				return err
-			}
+		ingress = make([]interface{}, len(ingressRead))
+		copy(ingress, ingressRead)
+		if tfErr := d.Set("ingress", ingressRead); tfErr != nil {
+			panic(tfErr)
+		}
+		// egress
+		egressRead, err := gressListCommand(ctx, cidr.(string), egress, wayEgress, httpGet, d, m, false)
+		if err != nil {
+			return err
+		}
+		egress = make([]interface{}, len(egressRead))
+		copy(egress, egressRead)
+		if tfErr := d.Set("egress", egressRead); tfErr != nil {
+			panic(tfErr)
 		}
 	}
 
@@ -364,25 +370,25 @@ func rulesRemoveOnCIDR(ctx context.Context, onCIDRList []interface{}, d *schema.
 	for _, cidr := range onCIDRList {
 		if d.HasChange("ingress") {
 			oldIngress, _ := d.GetChange("ingress")
-			err := gressListCommand(ctx, cidr.(string), oldIngress.(*schema.Set).List(), wayIngress, httpDel, d, m, false)
-			if err != nil {
+			if _, err := gressListCommand(
+				ctx, cidr.(string), oldIngress.(*schema.Set).List(), wayIngress, httpDel, d, m, false); err != nil {
 				return err
 			}
 		} else {
-			err := gressListCommand(ctx, cidr.(string), d.Get("ingress").(*schema.Set).List(), wayIngress, httpDel, d, m, false)
-			if err != nil {
+			if _, err := gressListCommand(
+				ctx, cidr.(string), d.Get("ingress").(*schema.Set).List(), wayIngress, httpDel, d, m, false); err != nil {
 				return err
 			}
 		}
 		if d.HasChange("egress") {
 			oldEgress, _ := d.GetChange("egress")
-			err := gressListCommand(ctx, cidr.(string), oldEgress.(*schema.Set).List(), wayEgress, httpDel, d, m, false)
-			if err != nil {
+			if _, err := gressListCommand(
+				ctx, cidr.(string), oldEgress.(*schema.Set).List(), wayEgress, httpDel, d, m, false); err != nil {
 				return err
 			}
 		} else {
-			err := gressListCommand(ctx, cidr.(string), d.Get("egress").(*schema.Set).List(), wayEgress, httpDel, d, m, false)
-			if err != nil {
+			if _, err := gressListCommand(
+				ctx, cidr.(string), d.Get("egress").(*schema.Set).List(), wayEgress, httpDel, d, m, false); err != nil {
 				return err
 			}
 		}
@@ -408,17 +414,17 @@ func rulesAddOncidr(ctx context.Context, onCIDRList []interface{}, d *schema.Res
 			//			computation of expanded deleted gress list
 			oldIngressSetExpandedRemove := computeOutSlicesOfMap(oldIngressSetDiffExpanded, newIngressSetDiffExpanded)
 
-			err = gressListCommand(ctx, cidr.(string), oldIngressSetExpandedRemove, wayIngress, httpDel, d, m, true)
-			if err != nil {
+			if _, err := gressListCommand(
+				ctx, cidr.(string), oldIngressSetExpandedRemove, wayIngress, httpDel, d, m, true); err != nil {
 				return err
 			}
-			err := gressListCommand(ctx, cidr.(string), newIngress.(*schema.Set).List(), wayIngress, httpPut, d, m, false)
-			if err != nil {
+			if _, err := gressListCommand(
+				ctx, cidr.(string), newIngress.(*schema.Set).List(), wayIngress, httpPut, d, m, false); err != nil {
 				return err
 			}
 		} else {
-			err := gressListCommand(ctx, cidr.(string), d.Get("ingress").(*schema.Set).List(), wayIngress, httpPut, d, m, false)
-			if err != nil {
+			if _, err := gressListCommand(
+				ctx, cidr.(string), d.Get("ingress").(*schema.Set).List(), wayIngress, httpPut, d, m, false); err != nil {
 				return err
 			}
 		}
@@ -433,17 +439,17 @@ func rulesAddOncidr(ctx context.Context, onCIDRList []interface{}, d *schema.Res
 			//			computation of expanded deleted gress list
 			oldEgressSetExpandedRemove := computeOutSlicesOfMap(oldEgressSetDiffExpanded, newEgressSetDiffExpanded)
 
-			err := gressListCommand(ctx, cidr.(string), oldEgressSetExpandedRemove, wayEgress, httpDel, d, m, true)
-			if err != nil {
+			if _, err := gressListCommand(
+				ctx, cidr.(string), oldEgressSetExpandedRemove, wayEgress, httpDel, d, m, true); err != nil {
 				return err
 			}
-			err = gressListCommand(ctx, cidr.(string), newEgress.(*schema.Set).List(), wayEgress, httpPut, d, m, false)
-			if err != nil {
+			if _, err := gressListCommand(
+				ctx, cidr.(string), newEgress.(*schema.Set).List(), wayEgress, httpPut, d, m, false); err != nil {
 				return err
 			}
 		} else {
-			err := gressListCommand(ctx, cidr.(string), d.Get("egress").(*schema.Set).List(), wayEgress, httpPut, d, m, false)
-			if err != nil {
+			if _, err := gressListCommand(
+				ctx, cidr.(string), d.Get("egress").(*schema.Set).List(), wayEgress, httpPut, d, m, false); err != nil {
 				return err
 			}
 		}
@@ -460,13 +466,13 @@ func gressListCommand(
 	d *schema.ResourceData,
 	m interface{},
 	cidrExpanded bool,
-) error {
+) ([]interface{}, error) {
 	switch method {
 	case httpGet:
 		if cidrExpanded {
-			return fmt.Errorf("internal error : gressListCommand Get with cidrExpanded")
+			return nil, fmt.Errorf("internal error : gressListCommand Get with cidrExpanded")
 		}
-		var saves []map[string]interface{}
+		var saves []interface{}
 		for _, gressElement := range gressList {
 			gressOK := true
 			gressOKnoPos := false
@@ -475,7 +481,7 @@ func gressListCommand(
 				err := gressCmd(ctx, onCIDR, gressExpandElement, way, httpGet, d, m)
 				if err != nil {
 					if !strings.Contains(err.Error(), noExists) {
-						return err
+						return nil, err
 					}
 					gressOK = false
 					if err.Error() == noExistsNoPosErr {
@@ -484,34 +490,21 @@ func gressListCommand(
 				}
 			}
 			if gressOK {
-				saves = append(saves, gressElement.(map[string]interface{}))
+				saves = append(saves, gressElement)
 			}
 			if gressOKnoPos {
-				gressElementNew := gressElement.(map[string]interface{})
-				gressElementNew["position"] = "?"
-				saves = append(saves, gressElementNew)
-			}
-		}
-		switch way {
-		case wayIngress:
-			tfErr := d.Set("ingress", saves)
-			if tfErr != nil {
-				panic(tfErr)
-			}
-		case wayEgress:
-			tfErr := d.Set("egress", saves)
-			if tfErr != nil {
-				panic(tfErr)
+				gressElement.(map[string]interface{})["position"] = "?"
+				saves = append(saves, gressElement)
 			}
 		}
 
-		return nil
+		return saves, nil
 	case httpDel:
 		if cidrExpanded {
 			for _, gressElement := range gressList {
 				err := gressCmd(ctx, onCIDR, gressElement, way, httpDel, d, m)
 				if err != nil {
-					return err
+					return nil, err
 				}
 			}
 		} else {
@@ -520,23 +513,23 @@ func gressListCommand(
 				for _, gressExpandElement := range gressExpand {
 					err := gressCmd(ctx, onCIDR, gressExpandElement, way, httpDel, d, m)
 					if err != nil {
-						return err
+						return nil, err
 					}
 				}
 			}
 		}
 
-		return nil
+		return nil, nil
 	case httpPut:
 		if cidrExpanded {
 			for _, gressElement := range gressList {
 				err := checkCIDRBlocksInMap(gressElement.(map[string]interface{}), ipv4ver)
 				if err != nil {
-					return err
+					return nil, err
 				}
 				err = gressCmd(ctx, onCIDR, gressElement, way, httpPut, d, m)
 				if err != nil {
-					return err
+					return nil, err
 				}
 			}
 		} else {
@@ -545,20 +538,20 @@ func gressListCommand(
 				for _, gressExpandElement := range gressExpand {
 					err := checkCIDRBlocksInMap(gressExpandElement.(map[string]interface{}), ipv4ver)
 					if err != nil {
-						return err
+						return nil, err
 					}
 					err = gressCmd(ctx, onCIDR, gressExpandElement, way, httpPut, d, m)
 					if err != nil {
-						return err
+						return nil, err
 					}
 				}
 			}
 		}
 
-		return nil
+		return nil, nil
 	}
 
-	return fmt.Errorf("internal error : unknown method for gressListCommand")
+	return nil, fmt.Errorf("internal error : unknown method for gressListCommand")
 }
 
 func gressCmd(

--- a/iptables/resource_rules.go
+++ b/iptables/resource_rules.go
@@ -452,8 +452,15 @@ func rulesAddOncidr(ctx context.Context, onCIDRList []interface{}, d *schema.Res
 	return nil
 }
 
-func gressListCommand(ctx context.Context, onCIDR string, gressList []interface{}, way string, method string,
-	d *schema.ResourceData, m interface{}, cidrExpanded bool) error {
+func gressListCommand(
+	ctx context.Context,
+	onCIDR string,
+	gressList []interface{},
+	way, method string,
+	d *schema.ResourceData,
+	m interface{},
+	cidrExpanded bool,
+) error {
 	switch method {
 	case httpGet:
 		if cidrExpanded {
@@ -554,8 +561,14 @@ func gressListCommand(ctx context.Context, onCIDR string, gressList []interface{
 	return fmt.Errorf("internal error : unknown method for gressListCommand")
 }
 
-func gressCmd(ctx context.Context, onCIDR string, gress interface{}, way string, method string,
-	d *schema.ResourceData, m interface{}) error {
+func gressCmd(
+	ctx context.Context,
+	onCIDR string,
+	gress interface{},
+	way, method string,
+	d *schema.ResourceData,
+	m interface{},
+) error {
 	client := m.(*Client)
 	var dstOk string
 	var srcOk string

--- a/iptables/resource_rules.go
+++ b/iptables/resource_rules.go
@@ -212,7 +212,7 @@ func resourceRulesCreate(ctx context.Context, d *schema.ResourceData, m interfac
 
 	checkProcject, err := client.chainAPIV4(ctx, d.Get("project").(string), httpGet)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed check project %s : %s", d.Get("project"), err))
+		return diag.FromErr(fmt.Errorf("failed check project %s : %w", d.Get("project"), err))
 	}
 	if !checkProcject {
 		return diag.FromErr(fmt.Errorf("failed unknown project %s", d.Get("project")))
@@ -307,7 +307,7 @@ func resourceRulesUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 	client := m.(*Client)
 	err = client.saveV4(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("iptables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 	}
 
 	return nil
@@ -323,7 +323,7 @@ func resourceRulesDelete(ctx context.Context, d *schema.ResourceData, m interfac
 	client := m.(*Client)
 	err = client.saveV4(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("iptables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("iptables save failed : %w", err))
 	}
 
 	return nil
@@ -662,56 +662,56 @@ func gressCmd(
 	case httpDel:
 		ruleexistsNoPos, err := client.rulesAPIV4(ctx, ruleNoPos, httpGet)
 		if err != nil {
-			return fmt.Errorf("check rules exists for %s %v failed : %s", onCIDR, ruleNoPos, err)
+			return fmt.Errorf("check rules exists for %s %v failed : %w", onCIDR, ruleNoPos, err)
 		}
 		if ruleexistsNoPos {
 			ret, err := client.rulesAPIV4(ctx, ruleNoPos, httpDel)
 			if !ret || err != nil {
-				return fmt.Errorf("delete rules %s %v failed : %s", onCIDR, ruleNoPos, err)
+				return fmt.Errorf("delete rules %s %v failed : %w", onCIDR, ruleNoPos, err)
 			}
 		}
 	case httpPut:
 		ruleexists, err := client.rulesAPIV4(ctx, rule, httpGet)
 		if err != nil {
-			return fmt.Errorf("check rules exists for %s %v failed : %s", onCIDR, rule, err)
+			return fmt.Errorf("check rules exists for %s %v failed : %w", onCIDR, rule, err)
 		}
 		if !ruleexists {
 			if ma["position"].(string) != "?" {
 				ruleexistsNoPos, err := client.rulesAPIV4(ctx, ruleNoPos, httpGet)
 				if err != nil {
-					return fmt.Errorf("check rules exists for %s %v failed : %s", onCIDR, ruleNoPos, err)
+					return fmt.Errorf("check rules exists for %s %v failed : %w", onCIDR, ruleNoPos, err)
 				}
 				if ruleexistsNoPos {
 					ret, err := client.rulesAPIV4(ctx, ruleNoPos, httpDel)
 					if !ret || err != nil {
-						return fmt.Errorf("delete rules with bad position %s %v failed : %s", onCIDR, ruleNoPos, err)
+						return fmt.Errorf("delete rules with bad position %s %v failed : %w", onCIDR, ruleNoPos, err)
 					}
 					ret, err = client.rulesAPIV4(ctx, rule, httpPut)
 					if !ret || err != nil {
-						return fmt.Errorf("add rules %s %v failed : %s", onCIDR, rule, err)
+						return fmt.Errorf("add rules %s %v failed : %w", onCIDR, rule, err)
 					}
 				} else {
 					ret, err := client.rulesAPIV4(ctx, rule, httpPut)
 					if !ret || err != nil {
-						return fmt.Errorf("add rules %s %v failed : %s", onCIDR, rule, err)
+						return fmt.Errorf("add rules %s %v failed : %w", onCIDR, rule, err)
 					}
 				}
 			} else {
 				ret, err := client.rulesAPIV4(ctx, rule, httpPut)
 				if !ret || err != nil {
-					return fmt.Errorf("add rules %s %v failed : %s", onCIDR, rule, err)
+					return fmt.Errorf("add rules %s %v failed : %w", onCIDR, rule, err)
 				}
 			}
 		}
 	case httpGet:
 		ruleexists, err := client.rulesAPIV4(ctx, rule, httpGet)
 		if err != nil {
-			return fmt.Errorf("check rules exists for %s %v failed : %s", onCIDR, rule, err)
+			return fmt.Errorf("check rules exists for %s %v failed : %w", onCIDR, rule, err)
 		}
 		if !ruleexists {
 			ruleexistsNoPos, err := client.rulesAPIV4(ctx, ruleNoPos, httpGet)
 			if err != nil {
-				return fmt.Errorf("check rules exists for %s %v failed : %s", onCIDR, ruleNoPos, err)
+				return fmt.Errorf("check rules exists for %s %v failed : %w", onCIDR, ruleNoPos, err)
 			}
 			if ruleexistsNoPos {
 				return fmt.Errorf(noExistsNoPosErr)

--- a/iptables/resource_rules_ipv6.go
+++ b/iptables/resource_rules_ipv6.go
@@ -210,7 +210,7 @@ func resourceRulesIPv6Create(ctx context.Context, d *schema.ResourceData, m inte
 
 	checkProcject, err := client.chainAPIV6(ctx, d.Get("project").(string), httpGet)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("check project %s failed : %s", d.Get("project"), err))
+		return diag.FromErr(fmt.Errorf("check project %s failed : %w", d.Get("project"), err))
 	}
 	if !checkProcject {
 		return diag.FromErr(fmt.Errorf("unknown project %s", d.Get("project")))
@@ -304,7 +304,7 @@ func resourceRulesIPv6Update(ctx context.Context, d *schema.ResourceData, m inte
 	client := m.(*Client)
 	err = client.saveV6(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("ip6tables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 
 	return nil
@@ -320,7 +320,7 @@ func resourceRulesIPv6Delete(ctx context.Context, d *schema.ResourceData, m inte
 	client := m.(*Client)
 	err = client.saveV6(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("ip6tables save failed : %s", err))
+		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 
 	return nil
@@ -662,56 +662,56 @@ func gressCmdV6(
 	case httpDel:
 		ruleexistsNoPos, err := client.rulesAPIV6(ctx, ruleNoPos, httpGet)
 		if err != nil {
-			return fmt.Errorf("check rules exists for %s %v failed : %s", onCIDR, ruleNoPos, err)
+			return fmt.Errorf("check rules exists for %s %v failed : %w", onCIDR, ruleNoPos, err)
 		}
 		if ruleexistsNoPos {
 			ret, err := client.rulesAPIV6(ctx, ruleNoPos, httpDel)
 			if !ret || err != nil {
-				return fmt.Errorf("delete rules %s %v failed : %s", onCIDR, ruleNoPos, err)
+				return fmt.Errorf("delete rules %s %v failed : %w", onCIDR, ruleNoPos, err)
 			}
 		}
 	case httpPut:
 		ruleexists, err := client.rulesAPIV6(ctx, rule, httpGet)
 		if err != nil {
-			return fmt.Errorf("check rules exists for %s %v failed : %s", onCIDR, rule, err)
+			return fmt.Errorf("check rules exists for %s %v failed : %w", onCIDR, rule, err)
 		}
 		if !ruleexists {
 			if ma["position"].(string) != "?" {
 				ruleexistsNoPos, err := client.rulesAPIV6(ctx, ruleNoPos, httpGet)
 				if err != nil {
-					return fmt.Errorf("check rules exists for %s %v failed : %s", onCIDR, ruleNoPos, err)
+					return fmt.Errorf("check rules exists for %s %v failed : %w", onCIDR, ruleNoPos, err)
 				}
 				if ruleexistsNoPos {
 					ret, err := client.rulesAPIV6(ctx, ruleNoPos, httpDel)
 					if !ret || err != nil {
-						return fmt.Errorf("delete rules with bad position %s %v failed : %s", onCIDR, ruleNoPos, err)
+						return fmt.Errorf("delete rules with bad position %s %v failed : %w", onCIDR, ruleNoPos, err)
 					}
 					ret, err = client.rulesAPIV6(ctx, rule, httpPut)
 					if !ret || err != nil {
-						return fmt.Errorf("add rules %s %v failed : %s", onCIDR, rule, err)
+						return fmt.Errorf("add rules %s %v failed : %w", onCIDR, rule, err)
 					}
 				} else {
 					ret, err := client.rulesAPIV6(ctx, rule, httpPut)
 					if !ret || err != nil {
-						return fmt.Errorf("add rules %s %v failed : %s", onCIDR, rule, err)
+						return fmt.Errorf("add rules %s %v failed : %w", onCIDR, rule, err)
 					}
 				}
 			} else {
 				ret, err := client.rulesAPIV6(ctx, rule, httpPut)
 				if !ret || err != nil {
-					return fmt.Errorf("add rules %s %v failed : %s", onCIDR, rule, err)
+					return fmt.Errorf("add rules %s %v failed : %w", onCIDR, rule, err)
 				}
 			}
 		}
 	case httpGet:
 		ruleexists, err := client.rulesAPIV6(ctx, rule, httpGet)
 		if err != nil {
-			return fmt.Errorf("check rules exists for %s %v failed : %s", onCIDR, rule, err)
+			return fmt.Errorf("check rules exists for %s %v failed : %w", onCIDR, rule, err)
 		}
 		if !ruleexists {
 			ruleexistsNoPos, err := client.rulesAPIV6(ctx, ruleNoPos, httpGet)
 			if err != nil {
-				return fmt.Errorf("check rules exists for %s %v failed : %s", onCIDR, ruleNoPos, err)
+				return fmt.Errorf("check rules exists for %s %v failed : %w", onCIDR, ruleNoPos, err)
 			}
 			if ruleexistsNoPos {
 				return fmt.Errorf(noExistsNoPosErr)

--- a/iptables/resource_rules_ipv6.go
+++ b/iptables/resource_rules_ipv6.go
@@ -457,8 +457,15 @@ func rulesAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.R
 	return nil
 }
 
-func gressListCommandV6(ctx context.Context, onCIDR string, gressList []interface{}, way string, method string,
-	d *schema.ResourceData, m interface{}, cidrExpanded bool) error {
+func gressListCommandV6(
+	ctx context.Context,
+	onCIDR string,
+	gressList []interface{},
+	way, method string,
+	d *schema.ResourceData,
+	m interface{},
+	cidrExpanded bool,
+) error {
 	switch method {
 	case httpGet:
 		if cidrExpanded {
@@ -559,8 +566,14 @@ func gressListCommandV6(ctx context.Context, onCIDR string, gressList []interfac
 	return fmt.Errorf("internal error : unknown method for gressListCommand")
 }
 
-func gressCmdV6(ctx context.Context, onCIDR string, gress interface{}, way string, method string,
-	d *schema.ResourceData, m interface{}) error {
+func gressCmdV6(
+	ctx context.Context,
+	onCIDR string,
+	gress interface{},
+	way, method string,
+	d *schema.ResourceData,
+	m interface{},
+) error {
 	client := m.(*Client)
 	if !client.IPv6 {
 		return fmt.Errorf("ipv6 not enable on provider")

--- a/iptables/resource_rules_ipv6.go
+++ b/iptables/resource_rules_ipv6.go
@@ -317,6 +317,7 @@ func resourceRulesIPv6Delete(ctx context.Context, d *schema.ResourceData, m inte
 }
 
 func rulesReadOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.ResourceData, m interface{}) error {
+	project := d.Get("project").(string)
 	ingress := d.Get("ingress").(*schema.Set).List()
 	if d.HasChange("ingress") {
 		oldIngress, _ := d.GetChange("ingress")
@@ -329,7 +330,7 @@ func rulesReadOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.
 	}
 	for _, cidr := range onCIDRList {
 		// ingress
-		ingressRead, err := gressListCommandV6(ctx, cidr.(string), ingress, wayIngress, httpGet, d, m, false)
+		ingressRead, err := gressListCommandV6(ctx, cidr.(string), ingress, wayIngress, httpGet, project, m, false)
 		if err != nil {
 			return err
 		}
@@ -339,7 +340,7 @@ func rulesReadOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.
 			panic(tfErr)
 		}
 		// egress
-		egressRead, err := gressListCommandV6(ctx, cidr.(string), egress, wayEgress, httpGet, d, m, false)
+		egressRead, err := gressListCommandV6(ctx, cidr.(string), egress, wayEgress, httpGet, project, m, false)
 		if err != nil {
 			return err
 		}
@@ -354,28 +355,29 @@ func rulesReadOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.
 }
 
 func rulesRemoveOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.ResourceData, m interface{}) error {
+	project := d.Get("project").(string)
 	for _, cidr := range onCIDRList {
 		if d.HasChange("ingress") {
 			oldIngress, _ := d.GetChange("ingress")
 			if _, err := gressListCommandV6(
-				ctx, cidr.(string), oldIngress.(*schema.Set).List(), wayIngress, httpDel, d, m, false); err != nil {
+				ctx, cidr.(string), oldIngress.(*schema.Set).List(), wayIngress, httpDel, project, m, false); err != nil {
 				return err
 			}
 		} else {
 			if _, err := gressListCommandV6(
-				ctx, cidr.(string), d.Get("ingress").(*schema.Set).List(), wayIngress, httpDel, d, m, false); err != nil {
+				ctx, cidr.(string), d.Get("ingress").(*schema.Set).List(), wayIngress, httpDel, project, m, false); err != nil {
 				return err
 			}
 		}
 		if d.HasChange("egress") {
 			oldEgress, _ := d.GetChange("egress")
 			if _, err := gressListCommandV6(
-				ctx, cidr.(string), oldEgress.(*schema.Set).List(), wayEgress, httpDel, d, m, false); err != nil {
+				ctx, cidr.(string), oldEgress.(*schema.Set).List(), wayEgress, httpDel, project, m, false); err != nil {
 				return err
 			}
 		} else {
 			if _, err := gressListCommandV6(
-				ctx, cidr.(string), d.Get("egress").(*schema.Set).List(), wayEgress, httpDel, d, m, false); err != nil {
+				ctx, cidr.(string), d.Get("egress").(*schema.Set).List(), wayEgress, httpDel, project, m, false); err != nil {
 				return err
 			}
 		}
@@ -385,6 +387,7 @@ func rulesRemoveOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schem
 }
 
 func rulesAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.ResourceData, m interface{}) error {
+	project := d.Get("project").(string)
 	for _, cidr := range onCIDRList {
 		if err := checkCIDRBlocksString(cidr.(string), ipv6ver); err != nil {
 			return err
@@ -401,16 +404,16 @@ func rulesAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.R
 			oldIngressSetExpandedRemove := computeOutSlicesOfMap(oldIngressSetDiffExpanded, newIngressSetDiffExpanded)
 
 			if _, err := gressListCommandV6(
-				ctx, cidr.(string), oldIngressSetExpandedRemove, wayIngress, httpDel, d, m, true); err != nil {
+				ctx, cidr.(string), oldIngressSetExpandedRemove, wayIngress, httpDel, project, m, true); err != nil {
 				return err
 			}
 			if _, err := gressListCommandV6(
-				ctx, cidr.(string), newIngress.(*schema.Set).List(), wayIngress, httpPut, d, m, false); err != nil {
+				ctx, cidr.(string), newIngress.(*schema.Set).List(), wayIngress, httpPut, project, m, false); err != nil {
 				return err
 			}
 		} else {
 			if _, err := gressListCommandV6(
-				ctx, cidr.(string), d.Get("ingress").(*schema.Set).List(), wayIngress, httpPut, d, m, false); err != nil {
+				ctx, cidr.(string), d.Get("ingress").(*schema.Set).List(), wayIngress, httpPut, project, m, false); err != nil {
 				return err
 			}
 		}
@@ -426,16 +429,16 @@ func rulesAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.R
 			oldEgressSetExpandedRemove := computeOutSlicesOfMap(oldEgressSetDiffExpanded, newEgressSetDiffExpanded)
 
 			if _, err := gressListCommandV6(
-				ctx, cidr.(string), oldEgressSetExpandedRemove, wayEgress, httpDel, d, m, true); err != nil {
+				ctx, cidr.(string), oldEgressSetExpandedRemove, wayEgress, httpDel, project, m, true); err != nil {
 				return err
 			}
 			if _, err := gressListCommandV6(
-				ctx, cidr.(string), newEgress.(*schema.Set).List(), wayEgress, httpPut, d, m, false); err != nil {
+				ctx, cidr.(string), newEgress.(*schema.Set).List(), wayEgress, httpPut, project, m, false); err != nil {
 				return err
 			}
 		} else {
 			if _, err := gressListCommandV6(
-				ctx, cidr.(string), d.Get("egress").(*schema.Set).List(), wayEgress, httpPut, d, m, false); err != nil {
+				ctx, cidr.(string), d.Get("egress").(*schema.Set).List(), wayEgress, httpPut, project, m, false); err != nil {
 				return err
 			}
 		}
@@ -448,8 +451,7 @@ func gressListCommandV6(
 	ctx context.Context,
 	onCIDR string,
 	gressList []interface{},
-	way, method string,
-	d *schema.ResourceData,
+	way, method, project string,
 	m interface{},
 	cidrExpanded bool,
 ) ([]interface{}, error) {
@@ -464,7 +466,7 @@ func gressListCommandV6(
 			gressOKnoPos := false
 			gressExpand := expandCIDRInGress(gressElement, ipv6ver)
 			for _, gressExpandElement := range gressExpand {
-				if err := gressCmdV6(ctx, onCIDR, gressExpandElement, way, httpGet, d, m); err != nil {
+				if err := gressCmdV6(ctx, onCIDR, gressExpandElement, way, httpGet, project, m); err != nil {
 					if !strings.Contains(err.Error(), noExists) {
 						return nil, err
 					}
@@ -487,7 +489,7 @@ func gressListCommandV6(
 	case httpDel:
 		if cidrExpanded {
 			for _, gressElement := range gressList {
-				if err := gressCmdV6(ctx, onCIDR, gressElement, way, httpDel, d, m); err != nil {
+				if err := gressCmdV6(ctx, onCIDR, gressElement, way, httpDel, project, m); err != nil {
 					return nil, err
 				}
 			}
@@ -495,7 +497,7 @@ func gressListCommandV6(
 			for _, gressElement := range gressList {
 				gressExpand := expandCIDRInGress(gressElement, ipv6ver)
 				for _, gressExpandElement := range gressExpand {
-					if err := gressCmdV6(ctx, onCIDR, gressExpandElement, way, httpDel, d, m); err != nil {
+					if err := gressCmdV6(ctx, onCIDR, gressExpandElement, way, httpDel, project, m); err != nil {
 						return nil, err
 					}
 				}
@@ -509,7 +511,7 @@ func gressListCommandV6(
 				if err := checkCIDRBlocksInMap(gressElement.(map[string]interface{}), ipv6ver); err != nil {
 					return nil, err
 				}
-				if err := gressCmdV6(ctx, onCIDR, gressElement, way, httpPut, d, m); err != nil {
+				if err := gressCmdV6(ctx, onCIDR, gressElement, way, httpPut, project, m); err != nil {
 					return nil, err
 				}
 			}
@@ -520,7 +522,7 @@ func gressListCommandV6(
 					if err := checkCIDRBlocksInMap(gressExpandElement.(map[string]interface{}), ipv6ver); err != nil {
 						return nil, err
 					}
-					if err := gressCmdV6(ctx, onCIDR, gressExpandElement, way, httpPut, d, m); err != nil {
+					if err := gressCmdV6(ctx, onCIDR, gressExpandElement, way, httpPut, project, m); err != nil {
 						return nil, err
 					}
 				}
@@ -534,12 +536,7 @@ func gressListCommandV6(
 }
 
 func gressCmdV6(
-	ctx context.Context,
-	onCIDR string,
-	gress interface{},
-	way, method string,
-	d *schema.ResourceData,
-	m interface{},
+	ctx context.Context, onCIDR string, gress interface{}, way, method, project string, m interface{},
 ) error {
 	client := m.(*Client)
 	if !client.IPv6 {
@@ -612,7 +609,7 @@ func gressCmdV6(
 		State:     ma["state"].(string),
 		Icmptype:  ma["icmptype"].(string),
 		Fragment:  ma["fragment"].(bool),
-		Chain:     d.Get("project").(string),
+		Chain:     project,
 		Proto:     ma["protocol"].(string),
 		IfaceIn:   ma["iface_in"].(string),
 		IfaceOut:  ma["iface_out"].(string),
@@ -628,7 +625,7 @@ func gressCmdV6(
 		State:     ma["state"].(string),
 		Icmptype:  ma["icmptype"].(string),
 		Fragment:  ma["fragment"].(bool),
-		Chain:     d.Get("project").(string),
+		Chain:     project,
 		Proto:     ma["protocol"].(string),
 		IfaceIn:   ma["iface_in"].(string),
 		IfaceOut:  ma["iface_out"].(string),

--- a/iptables/resource_rules_ipv6.go
+++ b/iptables/resource_rules_ipv6.go
@@ -227,8 +227,7 @@ func resourceRulesIPv6Read(ctx context.Context, d *schema.ResourceData, m interf
 	if d.HasChange("project") {
 		o, _ := d.GetChange("project")
 		if o != "" {
-			tfErr := d.Set("project", o)
-			if tfErr != nil {
+			if tfErr := d.Set("project", o); tfErr != nil {
 				panic(tfErr)
 			}
 
@@ -238,13 +237,11 @@ func resourceRulesIPv6Read(ctx context.Context, d *schema.ResourceData, m interf
 
 	if d.HasChange("on_cidr_blocks") {
 		oldOnCIDR, _ := d.GetChange("on_cidr_blocks")
-		err := rulesReadOnCIDRV6(ctx, oldOnCIDR.(*schema.Set).List(), d, m)
-		if err != nil {
+		if err := rulesReadOnCIDRV6(ctx, oldOnCIDR.(*schema.Set).List(), d, m); err != nil {
 			return diag.FromErr(err)
 		}
 	} else {
-		err := rulesReadOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m)
-		if err != nil {
+		if err := rulesReadOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -263,8 +260,7 @@ func resourceRulesIPv6Update(ctx context.Context, d *schema.ResourceData, m inte
 		}
 	}
 
-	err := checkRulesPositionAndCIDRList(d)
-	if err != nil {
+	if err := checkRulesPositionAndCIDRList(d); err != nil {
 		d.SetId("")
 
 		return diag.FromErr(err)
@@ -281,29 +277,25 @@ func resourceRulesIPv6Update(ctx context.Context, d *schema.ResourceData, m inte
 	if d.HasChange("on_cidr_blocks") {
 		oldOnCIDR, newOnCIDR := d.GetChange("on_cidr_blocks")
 		onCIDRRemove := computeRemove(oldOnCIDR.(*schema.Set).List(), newOnCIDR.(*schema.Set).List())
-		err = rulesRemoveOnCIDRV6(ctx, onCIDRRemove, d, m)
-		if err != nil {
+		if err := rulesRemoveOnCIDRV6(ctx, onCIDRRemove, d, m); err != nil {
 			d.SetId("")
 
 			return diag.FromErr(err)
 		}
-		err = rulesAddOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m)
-		if err != nil {
+		if err := rulesAddOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m); err != nil {
 			d.SetId("")
 
 			return diag.FromErr(err)
 		}
 	} else {
-		err = rulesAddOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m)
-		if err != nil {
+		if err := rulesAddOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m); err != nil {
 			d.SetId("")
 
 			return diag.FromErr(err)
 		}
 	}
 	client := m.(*Client)
-	err = client.saveV6(ctx)
-	if err != nil {
+	if err := client.saveV6(ctx); err != nil {
 		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 
@@ -311,15 +303,13 @@ func resourceRulesIPv6Update(ctx context.Context, d *schema.ResourceData, m inte
 }
 
 func resourceRulesIPv6Delete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	err := rulesRemoveOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m)
-	if err != nil {
+	if err := rulesRemoveOnCIDRV6(ctx, d.Get("on_cidr_blocks").(*schema.Set).List(), d, m); err != nil {
 		d.SetId(d.Get("name").(string) + "!")
 
 		return diag.FromErr(err)
 	}
 	client := m.(*Client)
-	err = client.saveV6(ctx)
-	if err != nil {
+	if err := client.saveV6(ctx); err != nil {
 		return diag.FromErr(fmt.Errorf("ip6tables save failed : %w", err))
 	}
 
@@ -396,8 +386,7 @@ func rulesRemoveOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schem
 
 func rulesAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.ResourceData, m interface{}) error {
 	for _, cidr := range onCIDRList {
-		err := checkCIDRBlocksString(cidr.(string), ipv6ver)
-		if err != nil {
+		if err := checkCIDRBlocksString(cidr.(string), ipv6ver); err != nil {
 			return err
 		}
 		if d.HasChange("ingress") {
@@ -411,7 +400,7 @@ func rulesAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.R
 			//			computation of expanded deleted gress list
 			oldIngressSetExpandedRemove := computeOutSlicesOfMap(oldIngressSetDiffExpanded, newIngressSetDiffExpanded)
 
-			if _, err = gressListCommandV6(
+			if _, err := gressListCommandV6(
 				ctx, cidr.(string), oldIngressSetExpandedRemove, wayIngress, httpDel, d, m, true); err != nil {
 				return err
 			}
@@ -440,7 +429,7 @@ func rulesAddOnCIDRV6(ctx context.Context, onCIDRList []interface{}, d *schema.R
 				ctx, cidr.(string), oldEgressSetExpandedRemove, wayEgress, httpDel, d, m, true); err != nil {
 				return err
 			}
-			if _, err = gressListCommandV6(
+			if _, err := gressListCommandV6(
 				ctx, cidr.(string), newEgress.(*schema.Set).List(), wayEgress, httpPut, d, m, false); err != nil {
 				return err
 			}
@@ -475,8 +464,7 @@ func gressListCommandV6(
 			gressOKnoPos := false
 			gressExpand := expandCIDRInGress(gressElement, ipv6ver)
 			for _, gressExpandElement := range gressExpand {
-				err := gressCmdV6(ctx, onCIDR, gressExpandElement, way, httpGet, d, m)
-				if err != nil {
+				if err := gressCmdV6(ctx, onCIDR, gressExpandElement, way, httpGet, d, m); err != nil {
 					if !strings.Contains(err.Error(), noExists) {
 						return nil, err
 					}
@@ -499,8 +487,7 @@ func gressListCommandV6(
 	case httpDel:
 		if cidrExpanded {
 			for _, gressElement := range gressList {
-				err := gressCmdV6(ctx, onCIDR, gressElement, way, httpDel, d, m)
-				if err != nil {
+				if err := gressCmdV6(ctx, onCIDR, gressElement, way, httpDel, d, m); err != nil {
 					return nil, err
 				}
 			}
@@ -508,8 +495,7 @@ func gressListCommandV6(
 			for _, gressElement := range gressList {
 				gressExpand := expandCIDRInGress(gressElement, ipv6ver)
 				for _, gressExpandElement := range gressExpand {
-					err := gressCmdV6(ctx, onCIDR, gressExpandElement, way, httpDel, d, m)
-					if err != nil {
+					if err := gressCmdV6(ctx, onCIDR, gressExpandElement, way, httpDel, d, m); err != nil {
 						return nil, err
 					}
 				}
@@ -520,12 +506,10 @@ func gressListCommandV6(
 	case httpPut:
 		if cidrExpanded {
 			for _, gressElement := range gressList {
-				err := checkCIDRBlocksInMap(gressElement.(map[string]interface{}), ipv6ver)
-				if err != nil {
+				if err := checkCIDRBlocksInMap(gressElement.(map[string]interface{}), ipv6ver); err != nil {
 					return nil, err
 				}
-				err = gressCmdV6(ctx, onCIDR, gressElement, way, httpPut, d, m)
-				if err != nil {
+				if err := gressCmdV6(ctx, onCIDR, gressElement, way, httpPut, d, m); err != nil {
 					return nil, err
 				}
 			}
@@ -533,12 +517,10 @@ func gressListCommandV6(
 			for _, gressElement := range gressList {
 				gressExpand := expandCIDRInGress(gressElement, ipv6ver)
 				for _, gressExpandElement := range gressExpand {
-					err := checkCIDRBlocksInMap(gressExpandElement.(map[string]interface{}), ipv6ver)
-					if err != nil {
+					if err := checkCIDRBlocksInMap(gressExpandElement.(map[string]interface{}), ipv6ver); err != nil {
 						return nil, err
 					}
-					err = gressCmdV6(ctx, onCIDR, gressExpandElement, way, httpPut, d, m)
-					if err != nil {
+					if err := gressCmdV6(ctx, onCIDR, gressExpandElement, way, httpPut, d, m); err != nil {
 						return nil, err
 					}
 				}


### PR DESCRIPTION
BUG FIXES:

* resource/`iptabes_nat`,`iptables_nat_ipv6`: fix reading nat blocks when a member of an on_cidr_blocks list is ok, but a previous member doesn't have all the snat/dnat rules
* resource/`iptables_rules`,`iptables_rules_ipv6`: fix reading gress blocks when a member of an on_cidr_blocks list is ok, but a previous member doesn't have all the ingress/egress rules

PATCH:

* minor refactoring to fix linters errors